### PR TITLE
changed volumePath to not use /ifs/volumes by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 NAS platforms.  In the true nature of API bindings, it is intended that the
 functions available are basically a direct implementation of what is available
 through the API.  There is however, an abstraction called object which can be
-used by things like `Docker`, `Mesos`, and
-[REX-Ray](https://github.com/emccode/rexray) to integrate Isilon.
+used by things like `Docker`, `Mesos`, and [REX-Ray](https://github.com/emccode/rexray) to integrate Isilon.
 
 ## API Compatibility
 Currently only tested with v7+.
@@ -53,7 +52,7 @@ Name | Description
 `GOISILON_GROUP` | the user's group
 `GOISILON_PASSWORD` | the password
 `GOISILON_INSECURE` | whether to skip SSL validation
-`GOISILON_VOLUMEPATH` | which base path to use when looking for volume directories
+`GOISILON_VOLUMEPATH` | base path to use for root volume directory. Defaults to `/ifs/volumes` when left blank.  **WARNING: the `username` is granted root privilege to the `volumePath`.**
 
 ## Contributions
 Please contribute!

--- a/api/v1/papi_connection.go
+++ b/api/v1/papi_connection.go
@@ -42,9 +42,13 @@ func New(endpoint string, insecure bool, username, group, password, volumePath s
 	if volumePath == "" {
 		volumePath = papiVolumesPath
 	} else if volumePath[0] == '/' {
-		volumePath = fmt.Sprintf("%s%s", papiVolumesPath, volumePath)
+		volumePath = fmt.Sprintf("%s", volumePath)
 	} else {
-		volumePath = fmt.Sprintf("%s/%s", papiVolumesPath, volumePath)
+		volumePath = fmt.Sprintf("/%s", volumePath)
+	}
+
+	if volumePath == "/ifs" || volumePath == "/ifs/data" || volumePath == "/ifs/data/Isilon_Support" || volumePath == "/ifs/home" || volumePath == "/ifs/home/ftp" || volumePath == "/ifs/.snapshot" {
+		return nil, errors.New("volumePath cannot be the root of /ifs, /ifs/data, /ifs/data/Isilon_Support, /ifs/home, /ifs/home/ftp, or /ifs/.snapshot")
 	}
 
 	var client *http.Client


### PR DESCRIPTION
Changed volume path to use `/ifs/volumes` only if `volumePath` is blank or not specified. This allows any other volumePath to be specified. This also removes a corner case where `/ifs/volumes` has been preallocated. I opted to not add `/ifs` as a precursor because there is an ability within Isilon to create root symlinks. If a path is heavily nested such as `/ifs/containers/k8/app0` it could be directed to the root as `/app0`.

This change is implemented to fix https://github.com/emccode/rexray/issues/506 where `/ifs/volumes` is not able to be used.