### PR TITLE
ACL Support

### DIFF
--- a/acls.go
+++ b/acls.go
@@ -1,0 +1,50 @@
+package goisilon
+
+import (
+	"golang.org/x/net/context"
+
+	api "github.com/emccode/goisilon/api/v2"
+)
+
+type ACL *api.ACL
+
+// GetVolumeACL returns the ACL for a volume.
+func (c *Client) GetVolumeACL(
+	ctx context.Context,
+	volumeName string) (ACL, error) {
+
+	return api.ACLInspect(ctx, c.API, volumeName)
+}
+
+// SetVolumeOwnerToCurrentUser sets the owner for a volume to the user that
+// was used to connect to the API.
+func (c *Client) SetVolumeOwnerToCurrentUser(
+	ctx context.Context,
+	volumeName string) error {
+
+	return c.SetVolumeOwner(ctx, volumeName, c.API.User())
+}
+
+// SetVolumeOwner sets the owner for a volume.
+func (c *Client) SetVolumeOwner(
+	ctx context.Context,
+	volumeName, userName string) error {
+
+	mode := api.FileMode(0777)
+
+	return api.ACLUpdate(
+		ctx,
+		c.API,
+		volumeName,
+		&api.ACL{
+			Action:        &api.PActionTypeReplace,
+			Authoritative: &api.PAuthoritativeTypeMode,
+			Owner: &api.Persona{
+				ID: &api.PersonaID{
+					ID:   userName,
+					Type: api.PersonaIDTypeUser,
+				},
+			},
+			Mode: &mode,
+		})
+}

--- a/acls_test.go
+++ b/acls_test.go
@@ -1,0 +1,91 @@
+package goisilon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	api "github.com/emccode/goisilon/api/v2"
+)
+
+func TestGetVolumeACL(t *testing.T) {
+	volumeName := "test_get_volume_acl"
+
+	// make sure the volume exists
+	client.CreateVolume(defaultCtx, volumeName)
+	volume, err := client.GetVolume(defaultCtx, volumeName, volumeName)
+	assertNoError(t, err)
+	assertNotNil(t, volume)
+
+	defer client.DeleteVolume(defaultCtx, volume.Name)
+
+	acl, err := client.GetVolumeACL(defaultCtx, volume.Name)
+	assertNoError(t, err)
+	assertNotNil(t, acl)
+
+	assertNotNil(t, acl.Owner)
+	assertNotNil(t, acl.Owner.Name)
+	assert.Equal(t, client.API.User(), *acl.Owner.Name)
+	assertNotNil(t, acl.Owner.Type)
+	assert.Equal(t, api.PersonaTypeUser, *acl.Owner.Type)
+	assertNotNil(t, acl.Owner.ID)
+	assert.Equal(t, "10", acl.Owner.ID.ID)
+	assert.Equal(t, api.PersonaIDTypeUID, acl.Owner.ID.Type)
+}
+
+func TestSetVolumeOwnerToCurrentUser(t *testing.T) {
+	volumeName := "test_set_volume_owner"
+
+	// make sure the volume exists
+	client.CreateVolume(defaultCtx, volumeName)
+	volume, err := client.GetVolume(defaultCtx, volumeName, volumeName)
+	assertNoError(t, err)
+	assertNotNil(t, volume)
+
+	defer client.DeleteVolume(defaultCtx, volume.Name)
+
+	acl, err := client.GetVolumeACL(defaultCtx, volume.Name)
+	assertNoError(t, err)
+	assertNotNil(t, acl)
+
+	assertNotNil(t, acl.Owner)
+	assertNotNil(t, acl.Owner.Name)
+	assert.Equal(t, client.API.User(), *acl.Owner.Name)
+	assertNotNil(t, acl.Owner.Type)
+	assert.Equal(t, api.PersonaTypeUser, *acl.Owner.Type)
+	assertNotNil(t, acl.Owner.ID)
+	assert.Equal(t, "10", acl.Owner.ID.ID)
+	assert.Equal(t, api.PersonaIDTypeUID, acl.Owner.ID.Type)
+
+	err = client.SetVolumeOwner(defaultCtx, volume.Name, "rexray")
+	assertNoError(t, err)
+
+	acl, err = client.GetVolumeACL(defaultCtx, volume.Name)
+	assertNoError(t, err)
+	assertNotNil(t, acl)
+
+	assertNotNil(t, acl.Owner)
+	assertNotNil(t, acl.Owner.Name)
+	assert.Equal(t, "rexray", *acl.Owner.Name)
+	assertNotNil(t, acl.Owner.Type)
+	assert.Equal(t, api.PersonaTypeUser, *acl.Owner.Type)
+	assertNotNil(t, acl.Owner.ID)
+	assert.Equal(t, "2000", acl.Owner.ID.ID)
+	assert.Equal(t, api.PersonaIDTypeUID, acl.Owner.ID.Type)
+
+	err = client.SetVolumeOwnerToCurrentUser(defaultCtx, volume.Name)
+	assertNoError(t, err)
+
+	acl, err = client.GetVolumeACL(defaultCtx, volume.Name)
+	assertNoError(t, err)
+	assertNotNil(t, acl)
+
+	assertNotNil(t, acl.Owner)
+	assertNotNil(t, acl.Owner.Name)
+	assert.Equal(t, client.API.User(), *acl.Owner.Name)
+	assertNotNil(t, acl.Owner.Type)
+	assert.Equal(t, api.PersonaTypeUser, *acl.Owner.Type)
+	assertNotNil(t, acl.Owner.ID)
+	assert.Equal(t, "10", acl.Owner.ID.ID)
+	assert.Equal(t, api.PersonaIDTypeUID, acl.Owner.ID.Type)
+}

--- a/api/v2/api_v2_acls.go
+++ b/api/v2/api_v2_acls.go
@@ -1,0 +1,239 @@
+package v2
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/emccode/goisilon/api"
+	"golang.org/x/net/context"
+)
+
+// AuthoritativeType is a possible value used with an ACL's Authoritative field.
+type AuthoritativeType uint8
+
+const (
+	// AuthoritativeTypeUnknown is an unknown AuthoritativeType.
+	AuthoritativeTypeUnknown AuthoritativeType = iota
+
+	// AuthoritativeTypeACL sets an ACL's Authoritative field to "acl".
+	AuthoritativeTypeACL
+
+	// AuthoritativeTypeMode sets an ACL's Authoritative field to "mode".
+	AuthoritativeTypeMode
+
+	authoritativeTypeCount
+)
+
+var (
+	// PAuthoritativeTypeACL is used to grab a pointer to a const.
+	PAuthoritativeTypeACL = AuthoritativeTypeACL
+
+	// PAuthoritativeTypeMode is used to grab a pointer to a const.
+	PAuthoritativeTypeMode = AuthoritativeTypeMode
+)
+
+const (
+	authoritativeTypeUnknownStr = "unknown"
+	authoritativeTypeACLStr     = "acl"
+	authoritativeTypeModeStr    = "mode"
+)
+
+var authoritativeTypesToStrs = [authoritativeTypeCount]string{
+	authoritativeTypeUnknownStr,
+	authoritativeTypeACLStr,
+	authoritativeTypeModeStr,
+}
+
+// ParseAuthoritativeType parses an AuthoritativeType from a string.
+func ParseAuthoritativeType(text string) AuthoritativeType {
+	switch {
+	case strings.EqualFold(text, authoritativeTypeACLStr):
+		return AuthoritativeTypeACL
+	case strings.EqualFold(text, authoritativeTypeModeStr):
+		return AuthoritativeTypeMode
+	}
+	return AuthoritativeTypeUnknown
+}
+
+// String returns the string representation of an AuthoritativeType value.
+func (p AuthoritativeType) String() string {
+	if p < (AuthoritativeTypeUnknown+1) || p >= authoritativeTypeCount {
+		return authoritativeTypesToStrs[AuthoritativeTypeUnknown]
+	}
+	return authoritativeTypesToStrs[p]
+}
+
+// MarshalJSON marshals an AuthoritativeType value to JSON.
+func (p AuthoritativeType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.String())
+}
+
+// UnmarshalJSON unmarshals an AuthoritativeType value from JSON.
+func (p *AuthoritativeType) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	*p = ParseAuthoritativeType(s)
+	return nil
+}
+
+// ActionType is a possible value used with an ACL's Action field.
+type ActionType uint8
+
+const (
+	// ActionTypeUnknown is an unknown ActionType.
+	ActionTypeUnknown ActionType = iota
+
+	// ActionTypeReplace sets an ACL's Action field to "replace".
+	ActionTypeReplace
+
+	// ActionTypeUpdate sets an ACL's Action field to "update".
+	ActionTypeUpdate
+
+	ActionTypeCount
+)
+
+var (
+	// PActionTypeReplace is used to grab a pointer to a const.
+	PActionTypeReplace = ActionTypeReplace
+
+	// PActionTypeUpdate is used to grab a pointer to a const.
+	PActionTypeUpdate = ActionTypeUpdate
+)
+
+const (
+	ActionTypeUnknownStr = "unknown"
+	ActionTypeReplaceStr = "replace"
+	ActionTypeUpdateStr  = "update"
+)
+
+var ActionTypesToStrs = [ActionTypeCount]string{
+	ActionTypeUnknownStr,
+	ActionTypeReplaceStr,
+	ActionTypeUpdateStr,
+}
+
+// ParseActionType parses an ActionType from a string.
+func ParseActionType(text string) ActionType {
+	switch {
+	case strings.EqualFold(text, ActionTypeReplaceStr):
+		return ActionTypeReplace
+	case strings.EqualFold(text, ActionTypeUpdateStr):
+		return ActionTypeUpdate
+	}
+	return ActionTypeUnknown
+}
+
+// String returns the string representation of an ActionType value.
+func (p ActionType) String() string {
+	if p < (ActionTypeUnknown+1) || p >= ActionTypeCount {
+		return ActionTypesToStrs[ActionTypeUnknown]
+	}
+	return ActionTypesToStrs[p]
+}
+
+// MarshalJSON marshals an ActionType value to JSON.
+func (p ActionType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.String())
+}
+
+// UnmarshalJSON unmarshals an ActionType value from JSON.
+func (p *ActionType) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	*p = ParseActionType(s)
+	return nil
+}
+
+// FileMode is an alias for the Go os.FileMode.
+type FileMode os.FileMode
+
+// String returns the string representation of an ActionType value.
+func (p FileMode) String() string {
+	return fmt.Sprintf("%04o", p)
+}
+
+// MarshalText marshals a FileMode value to text.
+func (p FileMode) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+var invalidFileMode = errors.New("invalid file mode")
+
+// UnmarshalText unmarshals a FileMode value from text.
+func (p *FileMode) UnmarshalText(data []byte) error {
+	if len(data) < 3 {
+		return invalidFileMode
+	}
+	if len(data) == 3 {
+		data = []byte{'0', data[0], data[1], data[2]}
+	}
+	m, err := strconv.ParseUint(string(data), 8, 32)
+	if err != nil {
+		return err
+	}
+	*p = FileMode(m)
+	return nil
+}
+
+// ACL is an Isilon Access Control List used for managing an object's security.
+type ACL struct {
+	Authoritative *AuthoritativeType `json:"authoritative,omitempty"`
+	Action        *ActionType        `json:"action,omitempty"`
+	Owner         *Persona           `json:"owner,omitempty"`
+	Group         *Persona           `json:"group,omitempty"`
+	Mode          *FileMode          `json:"mode,omitempty"`
+}
+
+var aclQueryString = map[string]string{"acl": ""}
+
+// ACLInspect GETs an ACL.
+func ACLInspect(
+	ctx context.Context,
+	client api.Client,
+	path string) (*ACL, error) {
+
+	var resp ACL
+
+	if err := client.Get(
+		ctx,
+		realNamespacePath(client),
+		path,
+		aclQueryString,
+		nil,
+		&resp); err != nil {
+
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// ACLUpdate PUTs an ACL.
+func ACLUpdate(
+	ctx context.Context,
+	client api.Client,
+	path string,
+	acl *ACL) error {
+
+	if err := client.Put(
+		ctx,
+		realNamespacePath(client),
+		path,
+		aclQueryString,
+		nil,
+		acl,
+		nil); err != nil {
+
+		return err
+	}
+
+	return nil
+}

--- a/api/v2/api_v2_types.go
+++ b/api/v2/api_v2_types.go
@@ -65,6 +65,12 @@ type Persona struct {
 	Name *string      `json:"name,omitempty"`
 }
 
+type persona struct {
+	ID   *PersonaID   `json:"id,omitempty"`
+	Type *PersonaType `json:"type,omitempty"`
+	Name *string      `json:"name,omitempty"`
+}
+
 type personaWithID struct {
 	ID *PersonaID `json:"id,omitempty"`
 }
@@ -88,12 +94,12 @@ func (p *Persona) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	var pid personaWithID
-	if err := json.Unmarshal(data, &pid); err == nil {
-		if pid.ID != nil {
-			p.ID = pid.ID
-			return nil
-		}
+	var pp persona
+	if err := json.Unmarshal(data, &pp); err == nil {
+		p.ID = pp.ID
+		p.Name = pp.Name
+		p.Type = pp.Type
+		return nil
 	}
 
 	var s string


### PR DESCRIPTION
This patch adds support for retrieving a IFS path's ACL information as
well as setting ownership for a given volume.