### PR TITLE
Recursive Volume Delete

### DIFF
--- a/api/api_logging.go
+++ b/api/api_logging.go
@@ -12,12 +12,16 @@ import (
 	"golang.org/x/net/context"
 )
 
+func isBinOctetBody(h http.Header) bool {
+	return h.Get(headerKeyContentType) == headerValContentTypeBinaryOctetStream
+}
+
 func logRequest(ctx context.Context, w io.Writer, req *http.Request) {
 	fmt.Fprintln(w, "")
 	fmt.Fprint(w, "    -------------------------- ")
 	fmt.Fprint(w, "GOISILON HTTP REQUEST")
 	fmt.Fprintln(w, " -------------------------")
-	buf, err := httputil.DumpRequest(req, true)
+	buf, err := httputil.DumpRequest(req, !isBinOctetBody(req.Header))
 	if err != nil {
 		return
 	}
@@ -33,9 +37,7 @@ func logResponse(ctx context.Context, res *http.Response) {
 	fmt.Fprint(w, "GOISILON HTTP RESPONSE")
 	fmt.Fprintln(w, " -------------------------")
 
-	buf, err := httputil.DumpResponse(
-		res,
-		res.Header.Get("Content-Type") != "application/octet-stream")
+	buf, err := httputil.DumpResponse(res, !isBinOctetBody(res.Header))
 	if err != nil {
 		return
 	}

--- a/api/api_ordered_values.go
+++ b/api/api_ordered_values.go
@@ -1,0 +1,347 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/url"
+	"strings"
+)
+
+var chrs = []byte(`,=&+%`)
+
+const (
+	chComa = iota
+	chEqul
+	chAmps
+	chPlus
+	chPrct
+)
+
+// OrderedValues maps a string key to a list of values and preserves insertion
+// order of the keys. It is typically used for query parameters and form values.
+// Unlike in the http.Header map, the keys in a Values map are case-sensitive.
+type OrderedValues [][][]byte
+
+// NewOrderedValues returns a new OrderedValues object.
+func NewOrderedValues(vals [][]string) OrderedValues {
+	if len(vals) == 0 {
+		return nil
+	}
+	var nov OrderedValues
+	for i := range vals {
+		var a [][]byte
+		for j := range vals[i] {
+			a = append(a, []byte(vals[i][j]))
+		}
+		nov = append(nov, a)
+	}
+	return nov
+}
+
+// StringAdd adds the value to key. It appends to any existing values
+// associated with key.
+func (v *OrderedValues) StringAdd(key, val string) {
+	if len(key) == 0 {
+		return
+	}
+	if len(val) == 0 {
+		v.Add([]byte(key), chrs[0:0])
+	} else {
+		v.Add([]byte(key), []byte(val))
+	}
+}
+
+// Add adds the value to key. It appends to any existing values associated with
+// key.
+func (v *OrderedValues) Add(key, val []byte) {
+	for i, j := range *v {
+		if len(j) > 0 && bytes.Equal(j[0], key) {
+			if len(val) > 0 {
+				(*v)[i] = append((*v)[i], val)
+			}
+			return
+		}
+	}
+	if len(val) == 0 {
+		*v = append(*v, [][]byte{key})
+	} else {
+		*v = append(*v, [][]byte{key, val})
+	}
+}
+
+// StringSet sets the key to value. It replaces any existing values.
+func (v *OrderedValues) StringSet(key, val string) {
+	if len(key) == 0 {
+		return
+	}
+	if len(val) == 0 {
+		v.Set([]byte(key), chrs[0:0])
+	} else {
+		v.Set([]byte(key), []byte(val))
+	}
+}
+
+// Set sets the key to value. It replaces any existing values.
+func (v *OrderedValues) Set(key, val []byte) {
+	for i, j := range *v {
+		if len(j) > 0 && bytes.Equal(j[0], key) {
+			if len(val) == 0 {
+				(*v)[i] = [][]byte{j[0]}
+			} else {
+				(*v)[i] = [][]byte{j[0], val}
+			}
+			return
+		}
+	}
+	if len(val) == 0 {
+		*v = append(*v, [][]byte{key})
+	} else {
+		*v = append(*v, [][]byte{key, val})
+	}
+}
+
+// StringGet gets the first value associated with the given key. If there are no
+// values associated with the key, Get returns the empty string. To access
+// multiple values, use the array directly.
+func (v *OrderedValues) StringGet(key string) string {
+	if len(key) == 0 {
+		return ""
+	}
+	return string(v.Get([]byte(key)))
+}
+
+// Get gets the first value associated with the given key. If there are no
+// values associated with the key, Get returns the empty string. To access
+// multiple values, use the array directly.
+func (v *OrderedValues) Get(key []byte) []byte {
+	for _, j := range *v {
+		if len(j) > 0 && bytes.Equal(j[0], key) {
+			if len(j) > 1 {
+				return j[1]
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+// StringGetOk returns a flag indicating whether or not the key exists. The
+// StringGet method can return an empty value for keys that do not have values,
+// so it cannot be trusted to indicate the existence of a key.
+func (v *OrderedValues) StringGetOk(key string) (string, bool) {
+	if len(key) == 0 {
+		return "", false
+	}
+	val, ok := v.GetOk([]byte(key))
+	if !ok {
+		return "", false
+	}
+	return string(val), true
+}
+
+// GetOk returns a flag indicating whether or not the key exists. The Get
+// method can return an empty value for keys that do not have values, so it
+// cannot be trusted to indicate the existence of a key.
+func (v *OrderedValues) GetOk(key []byte) ([]byte, bool) {
+	for _, j := range *v {
+		if len(j) > 0 && bytes.Equal(j[0], key) {
+			if len(j) > 1 {
+				return j[1], true
+			}
+			return nil, true
+		}
+	}
+	return nil, false
+}
+
+// StringDel deletes the values associated with key.
+func (v *OrderedValues) StringDel(key string) {
+	v.Del([]byte(key))
+}
+
+// Del deletes the values associated with key.
+func (v *OrderedValues) Del(key []byte) {
+	var (
+		i  int
+		ok bool
+		j  [][]byte
+	)
+	for i, j = range *v {
+		if len(j) > 0 && bytes.Equal(j[0], key) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return
+	}
+	copy((*v)[i:], (*v)[i+1:])
+	(*v)[len(*v)-1] = nil
+	*v = (*v)[:len(*v)-1]
+}
+
+// Encode encodes the values into “URL encoded” form ("bar=baz&foo=quux")
+// using insertion order.
+func (v *OrderedValues) Encode() string {
+	buf := &bytes.Buffer{}
+	v.EncodeTo(buf)
+	return buf.String()
+}
+
+// EncodeTo encodes the values into “URL encoded” form ("bar=baz&foo=quux")
+// using insertion order.
+func (v *OrderedValues) EncodeTo(w io.Writer) error {
+	first := true
+	for _, j := range *v {
+		if len(j) == 0 {
+			continue
+		}
+		if !first {
+			if _, err := w.Write(chrs[chAmps : chAmps+1]); err != nil {
+				return err
+			}
+		} else {
+			first = false
+		}
+		if _, err := w.Write(j[0]); err != nil {
+			return err
+		}
+		if len(j) == 1 {
+			continue
+		}
+		if _, err := w.Write(chrs[chEqul : chEqul+1]); err != nil {
+			return err
+		}
+		for e := 1; e < len(j); e++ {
+			if e > 1 {
+				if _, err := w.Write(chrs[chComa : chComa+1]); err != nil {
+					return err
+				}
+			}
+			if err := escapeTo(w, j[e]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (v *OrderedValues) String() string {
+	return v.Encode()
+}
+
+// ParseQuery parses the URL-encoded query string and returns an OrderedValues
+// object. ParseQuery may return nil if no valid query parameters are found. The
+// return error object is set to the first encountered decoding error, if any.
+func ParseQuery(query string) (OrderedValues, error) {
+	ov := OrderedValues{}
+	for query != "" {
+		if err := parseQuery(&ov, &query); err != nil {
+			return nil, err
+		}
+	}
+	return ov, nil
+}
+
+func parseQuery(m *OrderedValues, query *string) error {
+	var (
+		err   error
+		value string
+		key   = *query
+	)
+	if i := strings.IndexAny(key, "&;"); i >= 0 {
+		key, *query = key[:i], key[i+1:]
+	} else {
+		*query = ""
+	}
+	if key == "" {
+		return nil
+	}
+	if i := strings.Index(key, "="); i >= 0 {
+		key, value = key[:i], key[i+1:]
+	}
+	if key, err = url.QueryUnescape(key); err != nil {
+		return err
+	}
+	if value, err = url.QueryUnescape(value); err != nil {
+		return err
+	}
+	(*m).StringAdd(key, value)
+	return nil
+}
+
+var hexChars = []byte{
+	'0', '1', '2', '3', '4', '5', '6', '7',
+	'8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
+}
+
+func escapeTo(w io.Writer, s []byte) error {
+
+	var (
+		hexCount   = 0
+		spaceCount = 0
+	)
+
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if shouldEscape(c) {
+			if c == ' ' {
+				spaceCount++
+			} else {
+				hexCount++
+			}
+		}
+	}
+	if spaceCount == 0 && hexCount == 0 {
+		if _, err := w.Write(s); err != nil {
+			return err
+		}
+		return nil
+	}
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case c == ' ':
+			if _, err := w.Write(chrs[chPlus : chPlus+1]); err != nil {
+				return err
+			}
+		case shouldEscape(c):
+			if _, err := w.Write(chrs[chPrct : chPrct+1]); err != nil {
+				return err
+			}
+			c4, c15 := c>>4, c&15
+			if _, err := w.Write(hexChars[c4 : c4+1]); err != nil {
+				return err
+			}
+			if _, err := w.Write(hexChars[c15 : c15+1]); err != nil {
+				return err
+			}
+		default:
+			if _, err := w.Write(s[i : i+1]); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// shouldEscape returns true if the specified character should be escaped when
+// appearing in a URL string, according to RFC 3986.
+//
+// Please be informed that for now shouldEscape does not check all
+// reserved characters correctly. See golang.org/issue/5684.
+func shouldEscape(c byte) bool {
+	// §2.3 Unreserved characters (alphanum)
+	if 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' {
+		return false
+	}
+	switch c {
+	case '-', '_', '.', '~':
+		// §2.3 Unreserved characters (mark)
+		return false
+	case '$', '&', '+', ',', '/', ':', ';', '=', '?', '@':
+		return true
+	}
+	// Everything else must be escaped.
+	return true
+}

--- a/api/api_ordered_values_test.go
+++ b/api/api_ordered_values_test.go
@@ -1,0 +1,207 @@
+package api
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	b0 []byte
+	b1 []byte
+	b2 []byte
+	b3 []byte
+)
+
+func BenchmarkByteArraysSingle(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b0 = []byte{'a'}
+		b1 = []byte{'b'}
+		b2 = []byte{'c'}
+	}
+}
+
+func BenchmarkByteArraysMulti(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b3 = []byte{'a', 'b', 'c'}
+	}
+}
+
+func BenchmarkOrderedValuesEncode(b *testing.B) {
+	v := OrderedValues{
+		{[]byte("query")},
+		{[]byte("size"), []byte("2")},
+		{[]byte("detail"), []byte("owner"), []byte("group")},
+		{[]byte("info"), []byte("?")},
+	}
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			v.EncodeTo(os.Stderr)
+		}
+	})
+}
+
+func BenchmarkStringOrderedValuesEncode(b *testing.B) {
+	v := NewOrderedValues([][]string{
+		{"query"},
+		{"size", "2"},
+		{"detail", "owner", "group"},
+		{"info", "?"},
+	})
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			v.EncodeTo(os.Stderr)
+		}
+	})
+}
+
+func TestOrderedValuesEncode(t *testing.T) {
+	v := OrderedValues{
+		{[]byte("query")},
+		{[]byte("size"), []byte("2")},
+		{[]byte("detail"), []byte("owner"), []byte("group")},
+		{[]byte("info"), []byte("?")},
+	}
+	assert.Equal(t, "query&size=2&detail=owner,group&info=%3F", v.Encode())
+}
+
+func TestStringOrderedValuesEncode(t *testing.T) {
+	v := NewOrderedValues([][]string{
+		{"query"},
+		{"size", "2"},
+		{"detail", "owner", "group"},
+		{"info", "?"},
+	})
+	assert.Equal(t, "query&size=2&detail=owner,group&info=%3F", v.Encode())
+}
+
+func TestOrderedValuesGet(t *testing.T) {
+	v := OrderedValues{
+		{[]byte("query")},
+		{[]byte("size"), []byte("2")},
+		{[]byte("detail"), []byte("owner"), []byte("group")},
+	}
+	assert.Equal(t, "query&size=2&detail=owner,group", v.Encode())
+	assert.Equal(t, []byte(nil), v.Get([]byte("query")))
+	assert.Equal(t, []byte("2"), v.Get([]byte("size")))
+	assert.Equal(t, []byte("owner"), v.Get([]byte("detail")))
+}
+
+func TestStringOrderedValuesGet(t *testing.T) {
+	v := NewOrderedValues([][]string{
+		{"query"},
+		{"size", "2"},
+		{"detail", "owner", "group"},
+	})
+	assert.Equal(t, "query&size=2&detail=owner,group", v.Encode())
+	assert.Equal(t, "", v.StringGet("query"))
+	assert.Equal(t, "2", v.StringGet("size"))
+	assert.Equal(t, "owner", v.StringGet("detail"))
+}
+
+func TestOrderedValuesGetOk(t *testing.T) {
+	v := OrderedValues{
+		{[]byte("query")},
+		{[]byte("size"), []byte("2")},
+		{[]byte("detail"), []byte("owner"), []byte("group")},
+	}
+	assert.Equal(t, "query&size=2&detail=owner,group", v.Encode())
+	val, ok := v.GetOk([]byte("query"))
+	assert.Equal(t, []byte(nil), val)
+	assert.True(t, ok)
+	val, ok = v.GetOk([]byte("size"))
+	assert.Equal(t, []byte("2"), val)
+	assert.True(t, ok)
+	val, ok = v.GetOk([]byte("detail"))
+	assert.Equal(t, []byte("owner"), val)
+	assert.True(t, ok)
+	val, ok = v.GetOk([]byte("depth"))
+	assert.Equal(t, []byte(nil), val)
+	assert.False(t, ok)
+}
+
+func TestStringOrderedValuesGetOk(t *testing.T) {
+	v := NewOrderedValues([][]string{
+		{"query"},
+		{"size", "2"},
+		{"detail", "owner", "group"},
+	})
+	assert.Equal(t, "query&size=2&detail=owner,group", v.Encode())
+	val, ok := v.StringGetOk("query")
+	assert.Equal(t, "", val)
+	assert.True(t, ok)
+	val, ok = v.StringGetOk("size")
+	assert.Equal(t, "2", val)
+	assert.True(t, ok)
+	val, ok = v.StringGetOk("detail")
+	assert.Equal(t, "owner", val)
+	assert.True(t, ok)
+	val, ok = v.StringGetOk("depth")
+	assert.Equal(t, "", val)
+	assert.False(t, ok)
+}
+
+func TestOrderedValuesAdd(t *testing.T) {
+	var v OrderedValues
+	v.Add([]byte("query"), nil)
+	assert.Equal(t, "query", v.Encode())
+	v.Add([]byte("size"), []byte("2"))
+	assert.Equal(t, "query&size=2", v.Encode())
+	v.Add([]byte("detail"), []byte("owner"))
+	assert.Equal(t, "query&size=2&detail=owner", v.Encode())
+	v.Add([]byte("detail"), []byte("group"))
+	assert.Equal(t, "query&size=2&detail=owner,group", v.Encode())
+}
+
+func TestOrderedValuesSet(t *testing.T) {
+	var v OrderedValues
+	v.Set([]byte("query"), nil)
+	assert.Equal(t, "query", v.Encode())
+	v.Set([]byte("size"), []byte("2"))
+	assert.Equal(t, "query&size=2", v.Encode())
+	v.Set([]byte("detail"), []byte("owner"))
+	assert.Equal(t, "query&size=2&detail=owner", v.Encode())
+	v.Set([]byte("detail"), []byte("group"))
+	assert.Equal(t, "query&size=2&detail=group", v.Encode())
+	v.Add([]byte("detail"), []byte("owner"))
+	assert.Equal(t, "query&size=2&detail=group,owner", v.Encode())
+}
+
+func TestOrderedValuesDel(t *testing.T) {
+	v := OrderedValues{
+		{[]byte("query")},
+		{[]byte("size"), []byte("2")},
+		{[]byte("detail"), []byte("owner"), []byte("group")},
+	}
+	assert.Equal(t, "query&size=2&detail=owner,group", v.Encode())
+	v.Del([]byte("size"))
+	assert.Equal(t, "query&detail=owner,group", v.Encode())
+	v.Del([]byte("query"))
+	assert.Equal(t, "detail=owner,group", v.Encode())
+	v.Del([]byte("detail"))
+	assert.Equal(t, "", v.Encode())
+}
+
+func TestParseQuery(t *testing.T) {
+	tf := func(qs string) {
+		ov, err := ParseQuery(qs)
+		assertNoError(t, err)
+		assertLen(t, ov, 3)
+		assertLen(t, ov[0], 2)
+		assertLen(t, ov[1], 1)
+		assertLen(t, ov[2], 2)
+		assert.Equal(t, "Andrew Kutz", ov.StringGet("name"))
+		assert.Equal(t, "", ov.StringGet("active"))
+		_, ok := ov.StringGetOk("active")
+		assert.True(t, ok)
+		assert.Equal(t, "akutz", ov.StringGet("alias"))
+		assert.Equal(t, "name=Andrew+Kutz&active&alias=akutz", ov.Encode())
+	}
+	tf("name=Andrew%20Kutz&active&alias=akutz")
+	tf("name=Andrew+Kutz&active&alias=akutz")
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -6,12 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFormatAuthHeaderVal(t *testing.T) {
-	assert.Equal(
-		t, "Basic YWt1dHo6cGFzc3dvcmQ=",
-		fmtAuthHeaderVal("akutz", "password"))
-}
-
 func BenchmarkFormatAuthHeaderVal(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -21,4 +15,40 @@ func BenchmarkFormatAuthHeaderVal(b *testing.B) {
 			}
 		}
 	})
+}
+
+func TestFormatAuthHeaderVal(t *testing.T) {
+	assert.Equal(
+		t, "Basic YWt1dHo6cGFzc3dvcmQ=",
+		fmtAuthHeaderVal("akutz", "password"))
+}
+
+func assertLen(t *testing.T, obj interface{}, expLen int) {
+	if !assert.Len(t, obj, expLen) {
+		t.FailNow()
+	}
+}
+
+func assertError(t *testing.T, err error) {
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+}
+
+func assertNoError(t *testing.T, err error) {
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+}
+
+func assertNil(t *testing.T, i interface{}) {
+	if !assert.Nil(t, i) {
+		t.FailNow()
+	}
+}
+
+func assertNotNil(t *testing.T, i interface{}) {
+	if !assert.NotNil(t, i) {
+		t.FailNow()
+	}
 }

--- a/api/v1/api_v1_quotas.go
+++ b/api/v1/api_v1_quotas.go
@@ -96,6 +96,8 @@ func UpdateIsiQuotaHardThreshold(
 	return err
 }
 
+var byteArrPath = []byte("path")
+
 // DeleteIsiQuota removes the quota for a directory
 func DeleteIsiQuota(
 	ctx context.Context,
@@ -105,8 +107,11 @@ func DeleteIsiQuota(
 	// PAPI call: DELETE https://1.2.3.4:8080/platform/1/quota/quotas?path=/path/to/volume
 	// This will remove a the quota on a volume
 
-	var quotaResp isiQuotaListResp
-	err = client.Delete(ctx, quotaPath, "", map[string]string{"path": path}, nil, &quotaResp)
-
-	return err
+	return client.Delete(
+		ctx,
+		quotaPath,
+		"",
+		api.OrderedValues{{byteArrPath, []byte(path)}},
+		nil,
+		nil)
 }

--- a/api/v1/api_v1_snapshots.go
+++ b/api/v1/api_v1_snapshots.go
@@ -76,6 +76,7 @@ func CopyIsiSnapshot(
 
 	headers := map[string]string{
 		"x-isi-ifs-copy-source": path.Join(
+			"/",
 			realVolumeSnapshotPath(client, sourceSnapshotName),
 			sourceVolume),
 	}

--- a/api/v2/api_v2_acls.go
+++ b/api/v2/api_v2_acls.go
@@ -183,6 +183,15 @@ func (p *FileMode) UnmarshalText(data []byte) error {
 	return nil
 }
 
+// ParseFileMode parses a string and returns a FileMode.
+func ParseFileMode(s string) (FileMode, error) {
+	var fm FileMode
+	if err := fm.UnmarshalText([]byte(s)); err != nil {
+		return 0, err
+	}
+	return fm, nil
+}
+
 // ACL is an Isilon Access Control List used for managing an object's security.
 type ACL struct {
 	Authoritative *AuthoritativeType `json:"authoritative,omitempty"`
@@ -192,7 +201,7 @@ type ACL struct {
 	Mode          *FileMode          `json:"mode,omitempty"`
 }
 
-var aclQueryString = map[string]string{"acl": ""}
+var aclQueryString = api.OrderedValues{{[]byte("acl")}}
 
 // ACLInspect GETs an ACL.
 func ACLInspect(

--- a/api/v2/api_v2_fs.go
+++ b/api/v2/api_v2_fs.go
@@ -1,0 +1,380 @@
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/emccode/goisilon/api"
+	"golang.org/x/net/context"
+)
+
+// ContainerChild is a child object of a container.
+type ContainerChild struct {
+	Name  *string   `json:"name,omitempty"`
+	Path  *string   `json:"container_path,omitempty"`
+	Type  *string   `json:"type,omitempty"`
+	Owner *string   `json:"owner,omitempty"`
+	Group *string   `json:"group,omitempty"`
+	Mode  *FileMode `json:"mode,omitempty"`
+	Size  *int      `json:"size,omitempty"`
+}
+
+type resumeableContainerChildList struct {
+	Children []*ContainerChild `json:"children,omitempty"`
+	Resume   string            `json:"resume,omitempty"`
+}
+
+// ContainerChildList is a list of a container's children.
+type ContainerChildList []*ContainerChild
+
+// MarshalJSON marshals a ContainerChildList to JSON.
+func (l ContainerChildList) MarshalJSON() ([]byte, error) {
+	containers := struct {
+		Children []*ContainerChild `json:"children,omitempty"`
+	}{l}
+	return json.Marshal(containers)
+}
+
+// UnmarshalJSON unmarshals a ContainerChildList from JSON.
+func (l *ContainerChildList) UnmarshalJSON(text []byte) error {
+	containers := struct {
+		Children []*ContainerChild `json:"children,omitempty"`
+	}{}
+	if err := json.Unmarshal(text, &containers); err != nil {
+		return err
+	}
+	*l = containers.Children
+	return nil
+}
+
+// ContainerQuery is used to query a container.
+type ContainerQuery struct {
+	Result []string             `json:"result,omitempty"`
+	Scope  *ContainerQueryScope `json:"scope,omitempty"`
+}
+
+// ContainerQueryScope is the query's scope.
+type ContainerQueryScope struct {
+	Logic      string        `json:"logic,omitempty"`
+	Conditions []interface{} `json:"conditions,omitempty"`
+}
+
+// ContainerQueryScopeCondition is the query's condition.
+type ContainerQueryScopeCondition struct {
+	Operator string `json:"operator,omitempty"`
+	Attr     string `json:"attr,omitempty"`
+	Value    string `json:"value,omitempty"`
+}
+
+var containerChildrenGetAllDetail = []string{
+	"type",
+	"container_path",
+	"size",
+	"mode",
+	"owner",
+	"group",
+	"name",
+}
+
+var containerQueryAll = &ContainerQuery{
+	Result: containerChildrenGetAllDetail,
+}
+
+var containerQueryAllSubDirs = &ContainerQuery{
+	Result: containerChildrenGetAllDetail,
+	Scope: &ContainerQueryScope{
+		Logic: "and",
+		Conditions: []interface{}{
+			&ContainerQueryScopeCondition{
+				Operator: "=",
+				Attr:     "type",
+				Value:    "container",
+			},
+		},
+	},
+}
+
+var (
+	trueByteArr      = []byte("true")
+	falseByteArr     = []byte("false")
+	overwriteByteArr = []byte("overwrite")
+	recursiveByteArr = []byte("recursive")
+	typeByteArr      = []byte("type")
+	queryByteArr     = []byte("query")
+	limitByteArr     = []byte("limit")
+	resumeByteArr    = []byte("resume")
+	maxDepthByteArr  = []byte("max-depth")
+	sortQS           = [][]byte{[]byte("sort")}
+	detailQS         = [][]byte{[]byte("detail")}
+	sortDirAsc       = [][]byte{[]byte("dir"), []byte("ASC")}
+	sortDirDesc      = [][]byte{[]byte("dir"), []byte("DESC")}
+)
+
+func to2DByteArray(sa []string) [][]byte {
+	ba := make([][]byte, len(sa))
+	for i := 0; i < len(sa); i++ {
+		ba[i] = []byte(sa[i])
+	}
+	return ba
+}
+
+// ContainerChildrenGetQuery queries a container for children regardless of
+// ACLs preventing traversal.
+func ContainerChildrenGetQuery(
+	ctx context.Context,
+	client api.Client,
+	containerPath string,
+	limit, maxDepth int,
+	objectType, sortDir string,
+	sort, detail []string) (<-chan *ContainerChild, <-chan error) {
+
+	var (
+		ec  = make(chan error)
+		cc  = make(chan *ContainerChild)
+		wg  = &sync.WaitGroup{}
+		rnp = realNamespacePath(client)
+		qs  = api.OrderedValues{
+			{queryByteArr},
+			{limitByteArr, []byte(fmt.Sprintf("%d", limit))},
+			{maxDepthByteArr, []byte(fmt.Sprintf("%d", maxDepth))},
+		}
+	)
+
+	if objectType != "" {
+		qs.Set(typeByteArr, []byte(objectType))
+	}
+	if len(sort) > 0 {
+		if strings.EqualFold(sortDir, "asc") {
+			qs = append(qs, sortDirAsc)
+		} else {
+			qs = append(qs, sortDirDesc)
+		}
+		qs = append(qs, append(sortQS, to2DByteArray(sort)...))
+	}
+	if len(detail) > 0 {
+		qs = append(qs, append(detailQS, to2DByteArray(detail)...))
+	}
+
+	go func() {
+		for {
+			var resp resumeableContainerChildList
+			if err := client.Get(
+				ctx,
+				rnp,
+				containerPath,
+				qs,
+				nil,
+				&resp); err != nil {
+				ec <- err
+				close(ec)
+				close(cc)
+				return
+			}
+			wg.Add(1)
+			go func(resp *resumeableContainerChildList) {
+				defer wg.Done()
+				for _, c := range resp.Children {
+					cc <- c
+				}
+			}(&resp)
+			if resp.Resume == "" {
+				break
+			}
+			qs.Set(resumeByteArr, []byte(resp.Resume))
+		}
+		wg.Wait()
+		close(ec)
+		close(cc)
+	}()
+	return cc, ec
+}
+
+// ContainerChildrenGetAll GETs all descendent children of a container.
+func ContainerChildrenGetAll(
+	ctx context.Context,
+	client api.Client,
+	containerPath string) ([]*ContainerChild, error) {
+
+	var children []*ContainerChild
+
+	cc, ec := ContainerChildrenGetQuery(
+		ctx, client, containerPath,
+		2, -1, "", "", nil, containerChildrenGetAllDetail)
+
+	done := make(chan int)
+
+	go func() {
+		defer close(done)
+		for c := range cc {
+			children = append(children, c)
+		}
+	}()
+
+	for {
+		select {
+		case <-done:
+			return children, nil
+		case e := <-ec:
+			if e != nil {
+				return nil, e
+			}
+		}
+	}
+}
+
+// ContainerChildrenMapAll GETs all descendent children of a container and
+// returns a map with the children's paths as the key.
+func ContainerChildrenMapAll(
+	ctx context.Context,
+	client api.Client,
+	containerPath string) (map[string]*ContainerChild, error) {
+
+	resp, err := ContainerChildrenGetAll(ctx, client, containerPath)
+	if err != nil {
+		return nil, err
+	}
+
+	children := map[string]*ContainerChild{}
+	for _, v := range resp {
+		children[path.Join(*v.Path, *v.Name)] = v
+	}
+
+	return children, nil
+}
+
+// ContainerChildrenPostQuery queries a container for children with additional
+// traversal options and matching capabilities, but is subject to ACLs that
+// may prevent traversal.
+func ContainerChildrenPostQuery(
+	ctx context.Context,
+	client api.Client,
+	containerPath string,
+	limit, maxDepth int,
+	query *ContainerQuery) ([]*ContainerChild, error) {
+
+	var resp ContainerChildList
+
+	if err := client.Post(
+		ctx,
+		realNamespacePath(client),
+		containerPath,
+		api.OrderedValues{
+			{queryByteArr},
+			{limitByteArr, []byte(fmt.Sprintf("%d", limit))},
+			{maxDepthByteArr, []byte(fmt.Sprintf("%d", maxDepth))},
+		},
+		nil,
+		query,
+		&resp); err != nil {
+
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+var (
+	contCreateTTQueryString = api.OrderedValues{
+		{recursiveByteArr, trueByteArr},
+	}
+	contCreateFTQueryString = api.OrderedValues{
+		{overwriteByteArr, falseByteArr},
+		{recursiveByteArr, trueByteArr},
+	}
+	contCreateFFQueryString = api.OrderedValues{
+		{overwriteByteArr, falseByteArr},
+	}
+)
+
+// ContainerCreateDir creates a directory as a child object of a container.
+func ContainerCreateDir(
+	ctx context.Context,
+	client api.Client,
+	containerPath, dirName string,
+	fileMode FileMode,
+	overwrite, recursive bool) error {
+
+	var params api.OrderedValues
+	if overwrite && recursive {
+		params = contCreateTTQueryString
+	} else if !overwrite && !recursive {
+		params = contCreateFFQueryString
+	} else if !overwrite && recursive {
+		params = contCreateFTQueryString
+	}
+
+	return client.Put(
+		ctx,
+		realNamespacePath(client),
+		path.Join(containerPath, dirName),
+		params,
+		map[string]string{
+			"x-isi-ifs-target-type":    "container",
+			"x-isi-ifs-access-control": fileMode.String(),
+		},
+		nil,
+		nil)
+}
+
+var (
+	overwriteFalseQueryString = api.NewOrderedValues([][]string{
+		{"overwrite", "false"},
+	})
+	recursiveTrueQueryString = api.NewOrderedValues([][]string{
+		{"recursive", "true"},
+	})
+)
+
+// ContainerCreateFile creates a file as a child object of a container.
+func ContainerCreateFile(
+	ctx context.Context,
+	client api.Client,
+	containerPath, fileName string,
+	fileSize int,
+	fileMode FileMode,
+	fileHndl io.ReadCloser,
+	overwrite bool) error {
+
+	var params api.OrderedValues
+	if !overwrite {
+		params = overwriteFalseQueryString
+	}
+
+	return client.Put(
+		ctx,
+		realNamespacePath(client),
+		path.Join(containerPath, fileName),
+		params,
+		map[string]string{
+			"x-isi-ifs-target-type":    "object",
+			"x-isi-ifs-access-control": fileMode.String(),
+			"Content-Length":           fmt.Sprintf("%d", fileSize),
+		},
+		fileHndl,
+		nil)
+}
+
+// ContainerChildDelete deletes a child of a container.
+func ContainerChildDelete(
+	ctx context.Context,
+	client api.Client,
+	childPath string,
+	recursive bool) error {
+
+	var params api.OrderedValues
+	if recursive {
+		params = recursiveTrueQueryString
+	}
+
+	return client.Delete(
+		ctx,
+		realNamespacePath(client),
+		childPath,
+		params,
+		nil,
+		nil)
+}

--- a/exports_test.go
+++ b/exports_test.go
@@ -8,25 +8,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-func assertNoError(t *testing.T, err error) {
-	if !assert.NoError(t, err) {
-		t.Error(err)
-		t.FailNow()
-	}
-}
-
-func assertNil(t *testing.T, i interface{}) {
-	if !assert.Nil(t, i) {
-		t.FailNow()
-	}
-}
-
-func assertNotNil(t *testing.T, i interface{}) {
-	if !assert.NotNil(t, i) {
-		t.FailNow()
-	}
-}
-
 func TestExportsList(t *testing.T) {
 	volumeName1 := "test_get_exports1"
 	volumeName2 := "test_get_exports2"

--- a/goisilon_test.go
+++ b/goisilon_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	log "github.com/emccode/gournal"
 	glogrus "github.com/emccode/gournal/logrus"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
 
@@ -42,4 +43,34 @@ func TestMain(m *testing.M) {
 		log.WithError(err).Panic(defaultCtx, "error creating test client")
 	}
 	os.Exit(m.Run())
+}
+
+func assertLen(t *testing.T, obj interface{}, expLen int) {
+	if !assert.Len(t, obj, expLen) {
+		t.FailNow()
+	}
+}
+
+func assertError(t *testing.T, err error) {
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+}
+
+func assertNoError(t *testing.T, err error) {
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+}
+
+func assertNil(t *testing.T, i interface{}) {
+	if !assert.Nil(t, i) {
+		t.FailNow()
+	}
+}
+
+func assertNotNil(t *testing.T, i interface{}) {
+	if !assert.NotNil(t, i) {
+		t.FailNow()
+	}
 }

--- a/quota_test.go
+++ b/quota_test.go
@@ -6,10 +6,9 @@ import (
 )
 
 // Test both GetQuota() and SetQuota()
-func TestGetSetQuota(t *testing.T) {
-	t.SkipNow()
+func TestQuotaGetSet(t *testing.T) {
 
-	volumeName := "test_get_set_quota"
+	volumeName := "test_quota_get_set"
 	quotaSize := int64(12345)
 
 	// Setup the test
@@ -51,10 +50,9 @@ func TestGetSetQuota(t *testing.T) {
 }
 
 // Test UpdateQuota()
-func TestUpdateQuota(t *testing.T) {
-	t.SkipNow()
+func TestQuotaUpdate(t *testing.T) {
 
-	volumeName := "test_update_quota"
+	volumeName := "test_quota_update"
 	quotaSize := int64(12345)
 	updatedQuotaSize := int64(22345000)
 
@@ -104,10 +102,9 @@ func TestUpdateQuota(t *testing.T) {
 }
 
 // Test ClearQuota()
-func TestClearQuota(t *testing.T) {
-	t.SkipNow()
+func TestQuotaClear(t *testing.T) {
 
-	volumeName := "test_clear_quota"
+	volumeName := "test_quota_clear"
 	quotaSize := int64(12345)
 
 	// Setup the test

--- a/snapshots_test.go
+++ b/snapshots_test.go
@@ -5,12 +5,11 @@ import (
 	"testing"
 )
 
-func TestGetSnapshots(t *testing.T) {
-	t.SkipNow()
+func TestSnapshotsGet(t *testing.T) {
 
-	snapshotPath := "test_get_snapshots_volume"
-	snapshotName1 := "test_get_snapshots_name1"
-	snapshotName2 := "test_get_snapshots_name2"
+	snapshotPath := "test_snapshots_get_volume"
+	snapshotName1 := "test_snapshots_get_snapshot_0"
+	snapshotName2 := "test_snapshots_get_snapshot_1"
 
 	// create the test volume
 	_, err := client.CreateVolume(defaultCtx, snapshotPath)
@@ -78,14 +77,13 @@ func TestGetSnapshots(t *testing.T) {
 
 }
 
-func TestGetSnapshotsByPath(t *testing.T) {
-	t.SkipNow()
+func TestSnapshotsGetByPath(t *testing.T) {
 
-	snapshotPath1 := "test_get_snap_by_path_volume1"
-	snapshotPath2 := "test_get_snap_by_path_volume2"
-	snapshotName1 := "test_get_snapshots_by_path_name1"
-	snapshotName2 := "test_get_snapshots_by_path_name2"
-	snapshotName3 := "test_get_snapshots_by_path_name3"
+	snapshotPath1 := "test_snapshots_get_by_path_volume_1"
+	snapshotPath2 := "test_snapshots_get_by_path_volume_2"
+	snapshotName1 := "test_snapshots_get_by_path_snapshot_1"
+	snapshotName2 := "test_snapshots_get_by_path_snapshot_2"
+	snapshotName3 := "test_snapshots_get_by_path_snapshot_3"
 
 	// create the two test volumes
 	_, err := client.CreateVolume(defaultCtx, snapshotPath1)
@@ -164,11 +162,10 @@ func TestGetSnapshotsByPath(t *testing.T) {
 	}
 }
 
-func TestCreateSnapshot(t *testing.T) {
-	t.SkipNow()
+func TestSnapshotCreate(t *testing.T) {
 
-	snapshotPath := "test_create_snapshot_volume"
-	snapshotName := "test_create_snapshot_name"
+	snapshotPath := "test_snapshot_create_volume"
+	snapshotName := "test_snapshot_create_snapshot"
 
 	// create the test volume
 	_, err := client.CreateVolume(defaultCtx, snapshotPath)
@@ -209,11 +206,10 @@ func TestCreateSnapshot(t *testing.T) {
 	}
 }
 
-func TestRemoveSnapshot(t *testing.T) {
-	t.SkipNow()
+func TestSnapshotRemove(t *testing.T) {
 
-	snapshotPath := "test_remove_snapshot_volume"
-	snapshotName := "test_remove_snapshot_name"
+	snapshotPath := "test_snapshot_remove_volume"
+	snapshotName := "test_snapshot_remove_snapshot"
 
 	// create the test volume
 	_, err := client.CreateVolume(defaultCtx, snapshotPath)
@@ -248,13 +244,12 @@ func TestRemoveSnapshot(t *testing.T) {
 	}
 }
 
-func TestCopySnapshot(t *testing.T) {
-	t.SkipNow()
+func TestSnapshotCopy(t *testing.T) {
 
-	sourceSnapshotPath := "test_copy_snapshot_volume"
-	sourceSnapshotName := "test_copy_snapshot_name"
-	destinationVolume := "test_copy_snapshot_destination"
-	subdirectoryName := "test_sub_directory"
+	sourceSnapshotPath := "test_snapshot_copy_src_volume"
+	sourceSnapshotName := "test_snapshot_copy_src_snapshot"
+	destinationVolume := "test_snapshot_copy_dst_volume"
+	subdirectoryName := "test_snapshot_copy_sub_dir"
 	sourceSubDirectory := fmt.Sprintf("%s/%s", sourceSnapshotPath, subdirectoryName)
 	destinationSubDirectory := fmt.Sprintf("%s/%s", destinationVolume, subdirectoryName)
 

--- a/volume.go
+++ b/volume.go
@@ -1,13 +1,21 @@
 package goisilon
 
 import (
+	"os"
+	"path"
+	"strings"
+	"sync"
+
 	log "github.com/emccode/gournal"
 	"golang.org/x/net/context"
 
-	api "github.com/emccode/goisilon/api/v1"
+	apiv1 "github.com/emccode/goisilon/api/v1"
+	apiv2 "github.com/emccode/goisilon/api/v2"
 )
 
-type Volume *api.IsiVolume
+type Volume *apiv1.IsiVolume
+type VolumeChildren apiv2.ContainerChildList
+type VolumeChildrenMap map[string]*apiv2.ContainerChild
 
 //GetVolume returns a specific volume by name or ID
 func (c *Client) GetVolume(
@@ -16,24 +24,24 @@ func (c *Client) GetVolume(
 	if id != "" {
 		name = id
 	}
-	volume, err := api.GetIsiVolume(ctx, c.API, name)
+	volume, err := apiv1.GetIsiVolume(ctx, c.API, name)
 	if err != nil {
 		return nil, err
 	}
-	var isiVolume = &api.IsiVolume{Name: name, AttributeMap: volume.AttributeMap}
+	var isiVolume = &apiv1.IsiVolume{Name: name, AttributeMap: volume.AttributeMap}
 	return isiVolume, nil
 }
 
 //GetVolumes returns a list of volumes
 func (c *Client) GetVolumes(ctx context.Context) ([]Volume, error) {
 
-	volumes, err := api.GetIsiVolumes(ctx, c.API)
+	volumes, err := apiv1.GetIsiVolumes(ctx, c.API)
 	if err != nil {
 		return nil, err
 	}
 	var isiVolumes []Volume
 	for _, volume := range volumes.Children {
-		newVolume := &api.IsiVolume{Name: volume.Name}
+		newVolume := &apiv1.IsiVolume{Name: volume.Name}
 		isiVolumes = append(isiVolumes, newVolume)
 	}
 	return isiVolumes, nil
@@ -43,28 +51,132 @@ func (c *Client) GetVolumes(ctx context.Context) ([]Volume, error) {
 func (c *Client) CreateVolume(
 	ctx context.Context, name string) (Volume, error) {
 
-	_, err := api.CreateIsiVolume(ctx, c.API, name)
+	_, err := apiv1.CreateIsiVolume(ctx, c.API, name)
 	if err != nil {
 		return nil, err
 	}
 
-	var isiVolume = &api.IsiVolume{Name: name, AttributeMap: nil}
+	var isiVolume = &apiv1.IsiVolume{Name: name, AttributeMap: nil}
 	return isiVolume, nil
 }
 
-//DeleteVolume deletes a volume
+// DeleteVolume deletes a volume
 func (c *Client) DeleteVolume(
 	ctx context.Context, name string) error {
-
-	_, err := api.DeleteIsiVolume(ctx, c.API, name)
+	_, err := apiv1.DeleteIsiVolume(ctx, c.API, name)
 	return err
+}
+
+// ConcurrentHTTPConnections is the number of allowed concurrent HTTP
+// connections for API functions that attempt to send multiple API calls at
+// once.
+var ConcurrentHTTPConnections = 2
+
+func newConcurrentHTTPChan() chan bool {
+	c := make(chan bool, ConcurrentHTTPConnections)
+	for i := 0; i < ConcurrentHTTPConnections; i++ {
+		c <- true
+	}
+	return c
+}
+
+// ForceDeleteVolume force deletes a volume by resetting the ownership of
+// all descendent directories to the current user prior to issuing a delete
+// call.
+func (c *Client) ForceDeleteVolume(ctx context.Context, name string) error {
+
+	var (
+		user       = c.API.User()
+		vpl        = len(c.API.VolumesPath()) + 1
+		errs       = make(chan error)
+		queryDone  = make(chan int)
+		childPaths = make(chan string)
+		setACLWait = &sync.WaitGroup{}
+		setACLChan = newConcurrentHTTPChan()
+		setACLDone = make(chan int)
+		mode       = apiv2.FileMode(0755)
+		acl        = &apiv2.ACL{
+			Action:        &apiv2.PActionTypeReplace,
+			Authoritative: &apiv2.PAuthoritativeTypeMode,
+			Owner: &apiv2.Persona{
+				ID: &apiv2.PersonaID{
+					ID:   user,
+					Type: apiv2.PersonaIDTypeUser,
+				},
+			},
+			Mode: &mode,
+		}
+	)
+
+	go func() {
+		queryChan, queryErrs := apiv2.ContainerChildrenGetQuery(
+			ctx, c.API, name, 1000, -1, "container", "ASC",
+			[]string{"container_path", "name"},
+			[]string{"owner", "name", "container_path"})
+
+		go func() {
+			if err := <-queryErrs; err != nil {
+				errs <- err
+				close(errs)
+			}
+		}()
+
+		go func() {
+			for child := range queryChan {
+				if strings.EqualFold(user, *child.Owner) {
+					continue
+				}
+				setACLWait.Add(1)
+				go func(s string) {
+					childPaths <- s
+				}(path.Join(*child.Path, *child.Name)[vpl:])
+			}
+			close(queryDone)
+		}()
+	}()
+
+	go func() {
+		for childPath := range childPaths {
+			go func(childPath string) {
+				<-setACLChan
+				if err := apiv2.ACLUpdate(
+					ctx,
+					c.API,
+					childPath,
+					acl); err != nil {
+					go func(childPath string) {
+						childPaths <- childPath
+					}(childPath)
+				} else {
+					setACLWait.Done()
+				}
+				setACLChan <- true
+			}(childPath)
+		}
+	}()
+
+	go func() {
+		<-queryDone
+		setACLWait.Wait()
+		close(setACLDone)
+	}()
+
+	select {
+	case <-setACLDone:
+	case err := <-errs:
+		if err != nil {
+			return err
+		}
+	}
+
+	return c.DeleteVolume(ctx, name)
 }
 
 //CopyVolume creates a volume based on an existing volume
 func (c *Client) CopyVolume(
 	ctx context.Context, src, dest string) (Volume, error) {
 
-	_, err := api.CopyIsiVolume(ctx, c.API, src, dest)
+	_, err := apiv1.CopyIsiVolume(ctx, c.API, src, dest)
 	if err != nil {
 		return nil, err
 	}
@@ -84,6 +196,26 @@ func (c *Client) UnexportVolume(
 	ctx context.Context, name string) error {
 
 	return c.Unexport(ctx, name)
+}
+
+// QueryVolumeChildren retrieves a list of all of a volume's descendent files
+// and directories.
+func (c *Client) QueryVolumeChildren(
+	ctx context.Context, name string) (VolumeChildrenMap, error) {
+
+	return apiv2.ContainerChildrenMapAll(ctx, c.API, name)
+}
+
+// CreateVolumeDir creates a directory inside a volume.
+func (c *Client) CreateVolumeDir(
+	ctx context.Context,
+	volumeName, dirPath string,
+	fileMode os.FileMode,
+	overwrite, recursive bool) error {
+
+	return apiv2.ContainerCreateDir(
+		ctx, c.API, volumeName, dirPath,
+		apiv2.FileMode(fileMode), overwrite, recursive)
 }
 
 // GetVolumeExportMap returns a map that relates Volumes to their corresponding

--- a/volume_test.go
+++ b/volume_test.go
@@ -1,11 +1,19 @@
 package goisilon
 
 import (
+	"bytes"
 	"fmt"
+	"os"
+	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+
+	apiv2 "github.com/emccode/goisilon/api/v2"
 )
 
-func TestGetVolumes(*testing.T) {
+func TestVolumeList(*testing.T) {
 	volumeName1 := "test_get_volumes_name1"
 	volumeName2 := "test_get_volumes_name2"
 
@@ -66,7 +74,7 @@ func TestGetVolumes(*testing.T) {
 
 }
 
-func TestGetCreateVolume(*testing.T) {
+func TestVolumeGetCreate(*testing.T) {
 	volumeName := "test_get_create_volume_name"
 
 	// make sure the volume doesn't exist yet
@@ -96,7 +104,7 @@ func TestGetCreateVolume(*testing.T) {
 	}
 }
 
-func TestDeleteVolume(*testing.T) {
+func TestVolumeDelete(*testing.T) {
 	volumeName := "test_remove_volume_name"
 
 	// make sure the volume exists
@@ -125,7 +133,7 @@ func TestDeleteVolume(*testing.T) {
 	}
 }
 
-func TestCopyVolume(*testing.T) {
+func TestVolumeCopy(*testing.T) {
 	sourceVolumeName := "test_copy_source_volume_name"
 	destinationVolumeName := "test_copy_destination_volume_name"
 	subDirectoryName := "test_sub_directory"
@@ -182,7 +190,7 @@ func TestCopyVolume(*testing.T) {
 
 }
 
-func TestExportVolume(*testing.T) {
+func TestVolumeExport(*testing.T) {
 	// TODO: Make this more robust
 	_, err := client.ExportVolume(defaultCtx, "testing")
 	if err != nil {
@@ -191,7 +199,7 @@ func TestExportVolume(*testing.T) {
 
 }
 
-func TestUnexportVolume(*testing.T) {
+func TestVolumeUnexport(*testing.T) {
 	// TODO: Make this more robust
 	err := client.UnexportVolume(defaultCtx, "testing")
 	if err != nil {
@@ -200,16 +208,627 @@ func TestUnexportVolume(*testing.T) {
 
 }
 
-func TestPath(*testing.T) {
+func TestVolumePath(*testing.T) {
 	// TODO: Make this more robust
 	fmt.Println(client.API.VolumePath("testing"))
 }
 
-func TestGetVolumeExportMap(t *testing.T) {
+func TestVolumeGetExportMap(t *testing.T) {
 	// TODO: Make this more robust
 	volExMap, err := client.GetVolumeExportMap(defaultCtx, false)
 	assertNoError(t, err)
 	for v := range volExMap {
 		t.Logf("volName=%s, volPath=%s", v.Name, client.API.VolumePath(v.Name))
 	}
+}
+
+func TestVolumeQueryChildren(t *testing.T) {
+
+	var (
+		ctx = defaultCtx
+		//context.WithValue(defaultCtx, log.LevelKey(), log.InfoLevel)
+
+		err      error
+		volume   Volume
+		children VolumeChildrenMap
+
+		volumeName   = "test_volume_query_children"
+		dirPath0     = "dA"
+		dirPath0a    = "dA/dAA"
+		dirPath1     = "dA/dAA/dAAA"
+		dirPath2     = "dB/dBB"
+		dirPath3     = "dC"
+		dirPath4     = "dC/dCC"
+		fileName0    = "an_empty_file"
+		fileName1    = fileName0
+		fileName2    = fileName0
+		fileName3    = fileName0
+		volDirPath0  = path.Join(volumeName, dirPath0)
+		volDirPath0a = path.Join(volumeName, dirPath0a)
+		volDirPath1  = path.Join(volumeName, dirPath1)
+		volDirPath2  = path.Join(volumeName, dirPath2)
+		volDirPath3  = path.Join(volumeName, dirPath3)
+		volDirPath4  = path.Join(volumeName, dirPath4)
+		volFilePath0 = path.Join(volumeName, fileName0)
+		volFilePath1 = path.Join(volDirPath2, fileName1)
+		volFilePath2 = path.Join(volDirPath3, fileName2)
+		volFilePath3 = path.Join(volDirPath4, fileName3)
+		dirPath0Key  = path.Join(client.API.VolumePath(volumeName), dirPath0)
+		dirPath0aKey = path.Join(client.API.VolumePath(volumeName), dirPath0a)
+		dirPath1Key  = path.Join(client.API.VolumePath(volumeName), dirPath1)
+		dirPath2Key  = path.Join(client.API.VolumePath(volumeName), dirPath2)
+		dirPath3Key  = path.Join(client.API.VolumePath(volumeName), dirPath3)
+		dirPath4Key  = path.Join(client.API.VolumePath(volumeName), dirPath4)
+		filePath0Key = path.Join(client.API.VolumePath(volumeName), fileName0)
+		filePath1Key = path.Join(dirPath2Key, fileName1)
+		filePath2Key = path.Join(dirPath3Key, fileName2)
+		filePath3Key = path.Join(dirPath4Key, fileName3)
+
+		newUserName  = client.API.User()
+		newGroupName = newUserName
+		badUserID    = "999"
+		badGroupID   = "999"
+		badUserName  = "Unknown User"
+		badGroupName = "Unknown Group"
+
+		volChildCount = 9
+
+		newDirMode  = apiv2.FileMode(0755)
+		newFileMode = apiv2.FileMode(0644)
+		badDirMode  = apiv2.FileMode(0700)
+		badFileMode = apiv2.FileMode(0400)
+
+		newDirACL = &apiv2.ACL{
+			Action:        &apiv2.PActionTypeReplace,
+			Authoritative: &apiv2.PAuthoritativeTypeMode,
+			Owner: &apiv2.Persona{
+				ID: &apiv2.PersonaID{
+					ID:   newUserName,
+					Type: apiv2.PersonaIDTypeUser,
+				},
+			},
+			Group: &apiv2.Persona{
+				ID: &apiv2.PersonaID{
+					ID:   newGroupName,
+					Type: apiv2.PersonaIDTypeGroup,
+				},
+			},
+			Mode: &newDirMode,
+		}
+
+		newFileACL = &apiv2.ACL{
+			Action:        &apiv2.PActionTypeReplace,
+			Authoritative: &apiv2.PAuthoritativeTypeMode,
+			Owner: &apiv2.Persona{
+				ID: &apiv2.PersonaID{
+					ID:   newUserName,
+					Type: apiv2.PersonaIDTypeUser,
+				},
+			},
+			Group: &apiv2.Persona{
+				ID: &apiv2.PersonaID{
+					ID:   newGroupName,
+					Type: apiv2.PersonaIDTypeGroup,
+				},
+			},
+			Mode: &newFileMode,
+		}
+
+		badDirACL = &apiv2.ACL{
+			Action:        &apiv2.PActionTypeReplace,
+			Authoritative: &apiv2.PAuthoritativeTypeMode,
+			Owner: &apiv2.Persona{
+				ID: &apiv2.PersonaID{
+					ID:   badUserID,
+					Type: apiv2.PersonaIDTypeUID,
+				},
+			},
+			Group: &apiv2.Persona{
+				ID: &apiv2.PersonaID{
+					ID:   badGroupID,
+					Type: apiv2.PersonaIDTypeGID,
+				},
+			},
+			Mode: &badDirMode,
+		}
+
+		badFileACL = &apiv2.ACL{
+			Action:        &apiv2.PActionTypeReplace,
+			Authoritative: &apiv2.PAuthoritativeTypeMode,
+			Owner: &apiv2.Persona{
+				ID: &apiv2.PersonaID{
+					ID:   badUserID,
+					Type: apiv2.PersonaIDTypeUID,
+				},
+			},
+			Group: &apiv2.Persona{
+				ID: &apiv2.PersonaID{
+					ID:   badGroupID,
+					Type: apiv2.PersonaIDTypeGID,
+				},
+			},
+			Mode: &badFileMode,
+		}
+	)
+
+	defer client.ForceDeleteVolume(ctx, volumeName)
+
+	setACLsWithPaths := func(
+		ctx context.Context, acl *apiv2.ACL, paths ...string) {
+		for _, p := range paths {
+			assertNoError(
+				t,
+				apiv2.ACLUpdate(ctx, client.API, p, acl))
+		}
+	}
+
+	assertNewFileACL := func(cm map[string]*apiv2.ContainerChild, k string) {
+		if !assert.Equal(t, newFileMode, *cm[k].Mode) ||
+			!assert.Equal(t, newUserName, *cm[k].Owner) ||
+			!assert.Equal(t, newGroupName, *cm[k].Group) {
+			t.FailNow()
+		}
+	}
+
+	assertBadFileACL := func(cm map[string]*apiv2.ContainerChild, k string) {
+		if !assert.Equal(t, badFileMode, *cm[k].Mode) ||
+			!assert.Equal(t, badUserName, *cm[k].Owner) ||
+			!assert.Equal(t, badGroupName, *cm[k].Group) {
+			t.FailNow()
+		}
+	}
+
+	assertNewDirACL := func(cm map[string]*apiv2.ContainerChild, k string) {
+		if !assert.Equal(t, newDirMode, *cm[k].Mode) ||
+			!assert.Equal(t, newUserName, *cm[k].Owner) ||
+			!assert.Equal(t, newGroupName, *cm[k].Group) {
+			t.FailNow()
+		}
+	}
+
+	assertBadDirACL := func(cm map[string]*apiv2.ContainerChild, k string) {
+		if !assert.Equal(t, badDirMode, *cm[k].Mode) ||
+			!assert.Equal(t, badUserName, *cm[k].Owner) ||
+			!assert.Equal(t, badGroupName, *cm[k].Group) {
+			t.FailNow()
+		}
+	}
+
+	createObjs := func(ctx context.Context, createType int) {
+		// make sure the volume exists
+		client.CreateVolume(ctx, volumeName)
+		volume, err = client.GetVolume(ctx, volumeName, volumeName)
+		assertNoError(t, err)
+		assertNotNil(t, volume)
+
+		// assert the volume has no children
+		children, err = client.QueryVolumeChildren(ctx, volumeName)
+		assertNoError(t, err)
+		assertLen(t, children, 0)
+
+		switch createType {
+		case 0:
+			// create dirPath1
+			assertError(t, client.CreateVolumeDir(
+				ctx,
+				volumeName,
+				dirPath1,
+				os.FileMode(newDirMode),
+				false,
+				false))
+
+			// create dirPath1 again, recursively
+			assertNoError(t, client.CreateVolumeDir(
+				ctx,
+				volumeName,
+				dirPath1,
+				os.FileMode(newDirMode),
+				false,
+				true))
+
+			// create the second directory path
+			assertNoError(t, client.CreateVolumeDir(
+				ctx,
+				volumeName,
+				dirPath2,
+				os.FileMode(newDirMode),
+				true,
+				true))
+
+			// create file0
+			assertNoError(t, apiv2.ContainerCreateFile(
+				ctx,
+				client.API,
+				volumeName,
+				fileName0,
+				0,
+				newFileMode,
+				&bufReadCloser{&bytes.Buffer{}},
+				false))
+
+			// create file1
+			assertNoError(t, apiv2.ContainerCreateFile(
+				ctx,
+				client.API,
+				volDirPath2,
+				fileName1,
+				0,
+				newFileMode,
+				&bufReadCloser{&bytes.Buffer{}},
+				false))
+
+			// try and create file1 again; should fail
+			assertError(t, apiv2.ContainerCreateFile(
+				ctx,
+				client.API,
+				volDirPath2,
+				fileName1,
+				0,
+				newFileMode,
+				&bufReadCloser{&bytes.Buffer{}},
+				false))
+
+			// try and create file1 again; should work
+			assertNoError(t, apiv2.ContainerCreateFile(
+				ctx,
+				client.API,
+				volDirPath2,
+				fileName1,
+				0,
+				newFileMode,
+				&bufReadCloser{&bytes.Buffer{}},
+				true))
+
+			// create the third directory path
+			assertNoError(t, client.CreateVolumeDir(
+				ctx,
+				volumeName,
+				dirPath4,
+				os.FileMode(newDirMode),
+				true,
+				true))
+
+			setACLsWithPaths(
+				ctx, newDirACL,
+				volDirPath0, volDirPath1, volDirPath2, volDirPath3, volDirPath4)
+			setACLsWithPaths(ctx, newFileACL, volFilePath0, volFilePath1)
+			children, err = client.QueryVolumeChildren(ctx, volumeName)
+			assertNoError(t, err)
+			assertLen(t, children, volChildCount)
+			assertNewDirACL(children, dirPath0Key)
+			assertNewDirACL(children, dirPath1Key)
+			assertNewDirACL(children, dirPath2Key)
+			assertNewDirACL(children, dirPath3Key)
+			assertNewDirACL(children, dirPath4Key)
+			assertNewFileACL(children, filePath0Key)
+			assertNewFileACL(children, filePath1Key)
+		case 1:
+			// test a single root dir with good perms that has an empty sub-dir
+			// with bad perms
+			assertNoError(t, client.CreateVolumeDir(
+				ctx,
+				volumeName,
+				dirPath4,
+				os.FileMode(newDirMode),
+				true,
+				true))
+			setACLsWithPaths(ctx, newDirACL, volDirPath3, volDirPath4)
+			children, err = client.QueryVolumeChildren(ctx, volumeName)
+			assertNoError(t, err)
+			assertLen(t, children, 2)
+			assertNewDirACL(children, dirPath3Key)
+			assertNewDirACL(children, dirPath4Key)
+		case 2:
+			// test a single, empty root dir with bad perms
+			assertNoError(t, client.CreateVolumeDir(
+				ctx,
+				volumeName,
+				dirPath3,
+				os.FileMode(newDirMode),
+				true,
+				true))
+			setACLsWithPaths(ctx, newDirACL, volDirPath3)
+			children, err = client.QueryVolumeChildren(ctx, volumeName)
+			assertNoError(t, err)
+			assertLen(t, children, 1)
+			assertNewDirACL(children, dirPath3Key)
+		case 3:
+			// test a single, root dir with bad perms that has a single file in
+			// it where the file has good perms
+			assertNoError(t, client.CreateVolumeDir(
+				ctx,
+				volumeName,
+				dirPath3,
+				os.FileMode(newDirMode),
+				true,
+				true))
+			assertNoError(t, apiv2.ContainerCreateFile(
+				ctx,
+				client.API,
+				volDirPath3,
+				fileName2,
+				0,
+				newFileMode,
+				&bufReadCloser{&bytes.Buffer{}},
+				true))
+			setACLsWithPaths(ctx, newFileACL, volFilePath2)
+			setACLsWithPaths(ctx, newDirACL, volDirPath3)
+			children, err = client.QueryVolumeChildren(ctx, volumeName)
+			assertNoError(t, err)
+			assertLen(t, children, 2)
+			assertNewDirACL(children, dirPath3Key)
+			assertNewFileACL(children, filePath2Key)
+		case 4:
+			// test a single, root dir with bad perms that has a single sub-dir
+			// with good perms, and the sub-dir contains a file with good perms
+			assertNoError(t, client.CreateVolumeDir(
+				ctx,
+				volumeName,
+				dirPath4,
+				os.FileMode(newDirMode),
+				true,
+				true))
+			assertNoError(t, apiv2.ContainerCreateFile(
+				ctx,
+				client.API,
+				volDirPath4,
+				fileName3,
+				0,
+				newFileMode,
+				&bufReadCloser{&bytes.Buffer{}},
+				true))
+			setACLsWithPaths(ctx, newFileACL, volFilePath3)
+			setACLsWithPaths(ctx, newDirACL, volDirPath3, volDirPath4)
+			children, err = client.QueryVolumeChildren(ctx, volumeName)
+			assertNoError(t, err)
+			assertLen(t, children, 3)
+			assertNewDirACL(children, dirPath3Key)
+			assertNewDirACL(children, dirPath4Key)
+			assertNewFileACL(children, filePath3Key)
+		case 5:
+			// test a single, root dir with good perms that has a single sub-dir
+			// with bad perms, and the sub-dir contains a file with good perms
+			assertNoError(t, client.CreateVolumeDir(
+				ctx,
+				volumeName,
+				dirPath4,
+				os.FileMode(newDirMode),
+				true,
+				true))
+			assertNoError(t, apiv2.ContainerCreateFile(
+				ctx,
+				client.API,
+				volDirPath4,
+				fileName3,
+				0,
+				newFileMode,
+				&bufReadCloser{&bytes.Buffer{}},
+				true))
+			setACLsWithPaths(ctx, newFileACL, volFilePath3)
+			setACLsWithPaths(ctx, newDirACL, volDirPath3, volDirPath4)
+			children, err = client.QueryVolumeChildren(ctx, volumeName)
+			assertNoError(t, err)
+			assertLen(t, children, 3)
+			assertNewDirACL(children, dirPath3Key)
+			assertNewDirACL(children, dirPath4Key)
+			assertNewFileACL(children, filePath3Key)
+		case 6:
+			// test /dA/dAA/dAAA where dA has bad perms; the volume delete
+			// should fail
+			assertNoError(t, client.CreateVolumeDir(
+				ctx,
+				volumeName,
+				dirPath1,
+				os.FileMode(newDirMode),
+				true,
+				true))
+		}
+	}
+
+	// assert that ForceDeleteVolume works
+	createObjs(ctx, 0)
+	setACLsWithPaths(ctx, badFileACL, volFilePath0, volFilePath1)
+	setACLsWithPaths(ctx,
+		badDirACL, volDirPath4, volDirPath3, volDirPath1, volDirPath0)
+	children, err = client.QueryVolumeChildren(ctx, volumeName)
+	assertNoError(t, err)
+	assertLen(t, children, volChildCount)
+	assertBadDirACL(children, dirPath0Key)
+	assertBadDirACL(children, dirPath1Key)
+	assertBadDirACL(children, dirPath3Key)
+	assertBadDirACL(children, dirPath4Key)
+	assertBadFileACL(children, filePath0Key)
+	assertBadFileACL(children, filePath1Key)
+	// force delete the volume
+	assertNoError(t, client.ForceDeleteVolume(ctx, volumeName))
+
+	// assert that an initial delete will result in the removal of files
+	// and directories not in conflict
+	createObjs(ctx, 0)
+	setACLsWithPaths(ctx, badFileACL, volFilePath0, volFilePath1)
+	setACLsWithPaths(ctx,
+		badDirACL, volDirPath4, volDirPath3, volDirPath1, volDirPath0)
+	children, err = client.QueryVolumeChildren(ctx, volumeName)
+	assertNoError(t, err)
+	assertLen(t, children, volChildCount)
+	assertBadDirACL(children, dirPath0Key)
+	assertBadDirACL(children, dirPath1Key)
+	assertBadDirACL(children, dirPath3Key)
+	assertBadDirACL(children, dirPath4Key)
+	assertBadFileACL(children, filePath0Key)
+	assertBadFileACL(children, filePath1Key)
+	// attempt to delete the volume; should fail, but the following paths
+	// will have been removed:
+	//
+	// - /dB
+	// - /dB/dBB
+	// - /dB/dBB/an_empty_file
+	// - /an_empty_file
+	assertError(t, client.DeleteVolume(ctx, volumeName))
+	setACLsWithPaths(
+		ctx, newDirACL,
+		volDirPath0, volDirPath1, volDirPath3, volDirPath4)
+	children, err = client.QueryVolumeChildren(ctx, volumeName)
+	assertNoError(t, err)
+	assertLen(t, children, volChildCount-4)
+	assertNewDirACL(children, dirPath0Key)
+	assertNewDirACL(children, dirPath1Key)
+	assertNewDirACL(children, dirPath3Key)
+	assertNewDirACL(children, dirPath4Key)
+	// attempt to delete the volume; should succeed
+	assertNoError(t, client.DeleteVolume(ctx, volumeName))
+
+	// assert that a file with bad perms deep in the hierarchy won't prevent
+	// a delete
+	createObjs(ctx, 0)
+	setACLsWithPaths(ctx, badFileACL, volFilePath1)
+	children, err = client.QueryVolumeChildren(ctx, volumeName)
+	assertNoError(t, err)
+	assertLen(t, children, volChildCount)
+	assertBadFileACL(children, filePath1Key)
+	assertNoError(t, client.DeleteVolume(ctx, volumeName))
+
+	// assert that a root file with bad perms will not prevent a delete
+	createObjs(ctx, 0)
+	setACLsWithPaths(ctx, badFileACL, volFilePath0)
+	children, err = client.QueryVolumeChildren(ctx, volumeName)
+	assertNoError(t, err)
+	assertLen(t, children, volChildCount)
+	assertBadFileACL(children, filePath0Key)
+	assertNoError(t, client.DeleteVolume(ctx, volumeName))
+
+	// assert that a root-directory with an empty sub-dir with bad perms will
+	// not prevent a delete
+	createObjs(ctx, 1)
+	setACLsWithPaths(ctx, badDirACL, volDirPath4)
+	children, err = client.QueryVolumeChildren(ctx, volumeName)
+	assertNoError(t, err)
+	assertLen(t, children, 2)
+	assertBadDirACL(children, dirPath4Key)
+	assertNoError(t, client.DeleteVolume(ctx, volumeName))
+
+	// assert that an empty root-directory with bad perms will not prevent a
+	// delete
+	createObjs(ctx, 2)
+	setACLsWithPaths(ctx, badDirACL, volDirPath3)
+	children, err = client.QueryVolumeChildren(ctx, volumeName)
+	assertNoError(t, err)
+	assertLen(t, children, 1)
+	assertBadDirACL(children, dirPath3Key)
+	assertNoError(t, client.DeleteVolume(ctx, volumeName))
+
+	// assert that a root-directory with bad perms that contains a file with
+	// good perms will prevent a delete
+	createObjs(ctx, 3)
+	setACLsWithPaths(ctx, badDirACL, volDirPath3)
+	children, err = client.QueryVolumeChildren(ctx, volumeName)
+	assertNoError(t, err)
+	assertLen(t, children, 2)
+	assertBadDirACL(children, dirPath3Key)
+	assertNewFileACL(children, filePath2Key)
+	assertError(t, client.DeleteVolume(ctx, volumeName))
+	setACLsWithPaths(ctx, newDirACL, volDirPath3)
+	assertNoError(t, client.DeleteVolume(ctx, volumeName))
+
+	// assert the previous scenario will be handled by a force delete
+	createObjs(ctx, 3)
+	setACLsWithPaths(ctx, badDirACL, volDirPath3)
+	children, err = client.QueryVolumeChildren(ctx, volumeName)
+	assertNoError(t, err)
+	assertLen(t, children, 2)
+	assertBadDirACL(children, dirPath3Key)
+	assertNewFileACL(children, filePath2Key)
+	assertNoError(t, client.ForceDeleteVolume(ctx, volumeName))
+
+	// assert that a root-directory with bad perms that contains a sub-dir
+	// with good perms that contains a file with good perms prevents a
+	// delete
+	createObjs(ctx, 4)
+	setACLsWithPaths(ctx, badDirACL, volDirPath3)
+	children, err = client.QueryVolumeChildren(ctx, volumeName)
+	assertNoError(t, err)
+	assertLen(t, children, 3)
+	assertBadDirACL(children, dirPath3Key)
+	assertNewDirACL(children, dirPath4Key)
+	assertNewFileACL(children, filePath3Key)
+	assertError(t, client.DeleteVolume(ctx, volumeName))
+	setACLsWithPaths(ctx, newDirACL, volDirPath3)
+	assertNoError(t, client.DeleteVolume(ctx, volumeName))
+
+	// assert the previous scenario will be handled by a force delete
+	createObjs(ctx, 4)
+	setACLsWithPaths(ctx, badDirACL, volDirPath3)
+	children, err = client.QueryVolumeChildren(ctx, volumeName)
+	assertNoError(t, err)
+	assertLen(t, children, 3)
+	assertBadDirACL(children, dirPath3Key)
+	assertNewDirACL(children, dirPath4Key)
+	assertNewFileACL(children, filePath3Key)
+	assertNoError(t, client.ForceDeleteVolume(ctx, volumeName))
+
+	// assert a single, root dir with good perms that has a single sub-dir
+	// with bad perms, and the sub-dir contains a file with good perms prevents
+	// a delete
+	createObjs(ctx, 5)
+	setACLsWithPaths(ctx, badDirACL, volDirPath4)
+	children, err = client.QueryVolumeChildren(ctx, volumeName)
+	assertNoError(t, err)
+	assertLen(t, children, 3)
+	assertNewDirACL(children, dirPath3Key)
+	assertBadDirACL(children, dirPath4Key)
+	assertNewFileACL(children, filePath3Key)
+	assertError(t, client.DeleteVolume(ctx, volumeName))
+	setACLsWithPaths(ctx, newDirACL, volDirPath4)
+	assertNoError(t, client.DeleteVolume(ctx, volumeName))
+
+	// assert the previous scenario will be handled by a force delete
+	createObjs(ctx, 5)
+	setACLsWithPaths(ctx, badDirACL, volDirPath4)
+	children, err = client.QueryVolumeChildren(ctx, volumeName)
+	assertNoError(t, err)
+	assertLen(t, children, 3)
+	assertNewDirACL(children, dirPath3Key)
+	assertBadDirACL(children, dirPath4Key)
+	assertNewFileACL(children, filePath3Key)
+	assertNoError(t, client.ForceDeleteVolume(ctx, volumeName))
+
+	// test /dA/dAA/dAAA where dA has bad perms; the volume delete
+	// should fail
+	createObjs(ctx, 6)
+	setACLsWithPaths(ctx, badDirACL, volDirPath0a)
+	children, err = client.QueryVolumeChildren(ctx, volumeName)
+	assertNoError(t, err)
+	assertLen(t, children, 3)
+	assertNewDirACL(children, dirPath0Key)
+	assertBadDirACL(children, dirPath0aKey)
+	assertNewDirACL(children, dirPath1Key)
+	assertError(t, client.DeleteVolume(ctx, volumeName))
+	setACLsWithPaths(ctx, newDirACL, volDirPath0a)
+	children, err = client.QueryVolumeChildren(ctx, volumeName)
+	assertNoError(t, err)
+	assertLen(t, children, 3)
+	assertNoError(t, client.DeleteVolume(ctx, volumeName))
+
+	// assert the previous scenario will be handled by a force delete
+	createObjs(ctx, 6)
+	setACLsWithPaths(ctx, badDirACL, volDirPath0a)
+	children, err = client.QueryVolumeChildren(ctx, volumeName)
+	assertNoError(t, err)
+	assertLen(t, children, 3)
+	assertNewDirACL(children, dirPath0Key)
+	assertBadDirACL(children, dirPath0aKey)
+	assertNewDirACL(children, dirPath1Key)
+	assertNoError(t, client.ForceDeleteVolume(ctx, volumeName))
+}
+
+type bufReadCloser struct {
+	b *bytes.Buffer
+}
+
+func (b *bufReadCloser) Read(p []byte) (n int, err error) {
+	return b.b.Read(p)
+}
+
+func (b *bufReadCloser) Close() error {
+	return nil
 }


### PR DESCRIPTION
This patch adds new OneFS file system functions in order to support recursive volume deletions when the volume's immediate children have their permissions set such that would prevent deleting the volume.