### PR TITLE
Add support for using Access Points

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ variables to configure the GoIsilon client:
 #### Environment Variables
 Name | Description
 ---- | -----------
-`GOISILON_ENDPOINT` | the API endpoint, ex. `https://172.17.177.230:8080`
-`GOISILON_USERNAME` | the username
-`GOISILON_GROUP` | the user's group
-`GOISILON_PASSWORD` | the password
-`GOISILON_INSECURE` | whether to skip SSL validation
-`GOISILON_VOLUMEPATH` | which base path to use when looking for volume directories
+`GOISILON_ENDPOINT`   | the API endpoint, ex. `https://172.17.177.230:8080`
+`GOISILON_USERNAME`   | the username
+`GOISILON_GROUP`      | the user's group
+`GOISILON_PASSWORD`   | the password
+`GOISILON_INSECURE`   | whether to skip SSL validation
+`GOISILON_VOLUMEPATH` | which filesystem base path to use when looking for volume directories
+`GOISILON_ACCESSPATH` | (optional) URL base path to volume directories including access point. Defaults to `GOISILON_VOLUMEPATH` if not specified.
 
 ### Initialize a new client with options
 The following example demonstrates how to explicitly specify options when
@@ -51,7 +52,25 @@ client, err := NewClientWithArgs(
 	"userName",
 	"password",
 	true,
+	"",
 	"/ifs/volumes")
+if err != nil {
+	panic(err)
+}
+```
+
+Another example with Access Point, for users with limited permissions:
+
+```go
+client, err := NewClientWithArgs(
+	context.Background(),
+	"https://172.17.177.230:8080",
+	"groupName",
+	"userName",
+	"password",
+	true,
+	"/user1_access_point",
+	"/ifs/data/user1_volumes")
 if err != nil {
 	panic(err)
 }

--- a/api/v1/api_v1.go
+++ b/api/v1/api_v1.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path"
 	"strconv"
-	"strings"
 
 	"github.com/thecodeteam/goisilon/api"
 )
@@ -14,7 +13,7 @@ const (
 	exportsPath         = "platform/1/protocols/nfs/exports"
 	quotaPath           = "platform/1/quota/quotas"
 	snapshotsPath       = "platform/1/snapshot/snapshots"
-	volumesnapshotsPath = "/ifs/.snapshot"
+	volumesnapshotsPath = ".snapshot"
 )
 
 var (
@@ -22,14 +21,13 @@ var (
 )
 
 func realNamespacePath(client api.Client) string {
-	return path.Join(namespacePath, client.VolumesPath())
+	return path.Join(namespacePath, client.VolumesAccessPath())
 }
 
 func realexportsPath(client api.Client) string {
-	return path.Join(exportsPath, client.VolumesPath())
+	return path.Join(exportsPath, client.VolumesAccessPath())
 }
 
 func realVolumeSnapshotPath(client api.Client, name string) string {
-	parts := strings.SplitN(realNamespacePath(client), "/ifs/", 2)
-	return path.Join(parts[0], volumesnapshotsPath, name, parts[1])
+	return path.Join(realNamespacePath(client), volumesnapshotsPath, name)
 }

--- a/api/v2/api_v2.go
+++ b/api/v2/api_v2.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path"
 	"strconv"
-	"strings"
 
 	"github.com/thecodeteam/goisilon/api"
 )
@@ -14,7 +13,7 @@ const (
 	exportsPath         = "platform/2/protocols/nfs/exports"
 	quotaPath           = "platform/2/quota/quotas"
 	snapshotsPath       = "platform/2/snapshot/snapshots"
-	volumeSnapshotsPath = "/ifs/.snapshot"
+	volumeSnapshotsPath = ".snapshot"
 )
 
 var (
@@ -23,14 +22,13 @@ var (
 )
 
 func realNamespacePath(c api.Client) string {
-	return path.Join(namespacePath, c.VolumesPath())
+	return path.Join(namespacePath, c.VolumesAccessPath())
 }
 
 func realExportsPath(c api.Client) string {
-	return path.Join(exportsPath, c.VolumesPath())
+	return path.Join(exportsPath, c.VolumesAccessPath())
 }
 
 func realVolumeSnapshotPath(c api.Client, name string) string {
-	parts := strings.SplitN(realNamespacePath(c), "/ifs/", 2)
-	return path.Join(parts[0], volumeSnapshotsPath, name, parts[1])
+	return path.Join(realNamespacePath(c), volumeSnapshotsPath, name)
 }

--- a/api/v2/api_v2_acls.go
+++ b/api/v2/api_v2_acls.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/thecodeteam/goisilon/api"
 	"context"
+	"github.com/thecodeteam/goisilon/api"
 )
 
 // AuthoritativeType is a possible value used with an ACL's Authoritative field.

--- a/api/v2/api_v2_fs.go
+++ b/api/v2/api_v2_fs.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/thecodeteam/goisilon/api"
 	"context"
+	"github.com/thecodeteam/goisilon/api"
 )
 
 // ContainerChild is a child object of a container.

--- a/client.go
+++ b/client.go
@@ -25,6 +25,7 @@ func NewClient(ctx context.Context) (*Client, error) {
 		os.Getenv("GOISILON_USERNAME"),
 		os.Getenv("GOISILON_GROUP"),
 		os.Getenv("GOISILON_PASSWORD"),
+		os.Getenv("GOISILON_ACCESSPATH"),
 		os.Getenv("GOISILON_VOLUMEPATH"))
 }
 
@@ -32,16 +33,18 @@ func NewClientWithArgs(
 	ctx context.Context,
 	endpoint string,
 	insecure bool,
-	user, group, pass, volumesPath string) (*Client, error) {
+	user, group, pass,
+	volumesAccessPath string, volumesPath string) (*Client, error) {
 
 	timeout, _ := time.ParseDuration(os.Getenv("GOISILON_TIMEOUT"))
 
 	client, err := api.New(
 		ctx, endpoint, user, pass, group,
 		&api.ClientOptions{
-			Insecure:    insecure,
-			VolumesPath: volumesPath,
-			Timeout:     timeout,
+			Insecure:          insecure,
+			VolumesAccessPath: volumesAccessPath,
+			VolumesPath:       volumesPath,
+			Timeout:           timeout,
 		})
 	if err != nil {
 		return nil, err

--- a/goisilon_test.go
+++ b/goisilon_test.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	log "github.com/akutz/gournal"
 	glogrus "github.com/akutz/gournal/logrus"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 var (

--- a/volume.go
+++ b/volume.go
@@ -87,7 +87,7 @@ func (c *Client) ForceDeleteVolume(ctx context.Context, name string) error {
 
 	var (
 		user       = c.API.User()
-		vpl        = len(c.API.VolumesPath()) + 1
+		vpl        = len(c.API.VolumesAccessPath()) + 1
 		errs       = make(chan error)
 		queryDone  = make(chan int)
 		childPaths = make(chan string)


### PR DESCRIPTION
You can access the file system namespace through an access point. The default namespace access point for the OneFS file system is `/ifs`.

If your Isilon user is not root and has no access to the default `/ifs` access point, then you need to specify your access point in the client. It will be used in folder/volume manipulation through the REST Namespace interface. VolumePath (which is absolute filesystem path) will be used in quota/export manipulation through the REST Platform interface.

For root user it does not matter since:
VolumePath (URL) = VolumeAccessPath (Filesystem) = `/ifs/SOME_PATH`

New VolumeAccessPath defaults to VolumePath for backward compatibility with previous configurations.

Closes #34 