### PR TITLE
Parse /platform/latest to float32 instead of uint8

### DIFF
--- a/acls.go
+++ b/acls.go
@@ -3,7 +3,7 @@ package goisilon
 import (
 	"context"
 
-	api "github.com/thecodeteam/goisilon/api/v2"
+	api "github.com/hpanike/goisilon/api/v2"
 )
 
 type ACL *api.ACL

--- a/acls_test.go
+++ b/acls_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	api "github.com/thecodeteam/goisilon/api/v2"
+	api "github.com/hpanike/goisilon/api/v2"
 )
 
 func TestGetVolumeACL(t *testing.T) {

--- a/api/api.go
+++ b/api/api.go
@@ -179,7 +179,7 @@ func New(
 	}
 
 	if resp.Latest != nil {
-		i, err := strconv.ParseUint(*resp.Latest, 10, 8)
+		i, err := strconv.ParseFloat(*resp.Latest, 64)
 		if err != nil {
 			return nil, err
 		}

--- a/api/api.go
+++ b/api/api.go
@@ -297,6 +297,8 @@ func (c *client) DoWithHeaders(
 	res, isDebugLog, err := c.DoAndGetResponseBody(
 		ctx, method, uri, id, params, headers, body)
 	if err != nil {
+		fmt.Printf("Response Body Actual: %v", res.Body)
+		fmt.Printf("Errored out here.")
 		return err
 	}
 	defer res.Body.Close()

--- a/api/api.go
+++ b/api/api.go
@@ -17,7 +17,7 @@ import (
 
 	log "github.com/akutz/gournal"
 
-	"github.com/thecodeteam/goisilon/api/json"
+	"github.com/hpanike/goisilon/api/json"
 )
 
 const (

--- a/api/api.go
+++ b/api/api.go
@@ -101,7 +101,7 @@ type client struct {
 	user string
 	grup string
 	volp string
-	apiv uint8
+	apiv float32
 }
 
 type apiVerResponse struct {
@@ -126,7 +126,7 @@ type ClientOptions struct {
 	// Insecure is a flag that indicates whether or not to supress SSL errors.
 	Insecure bool
 
-	// VolumesPath is the location on the Isilon server where volumes are
+	// VolumesPath is the location on the Iilon server where volumes are
 	// stored.
 	VolumesPath string
 
@@ -179,11 +179,11 @@ func New(
 	}
 
 	if resp.Latest != nil {
-		i, err := strconv.ParseFloat(*resp.Latest, 64)
+		i, err := strconv.ParseFloat(*resp.Latest, 32)
 		if err != nil {
 			return nil, err
 		}
-		c.apiv = uint8(i)
+		c.apiv = float32(i)
 	} else {
 		c.apiv = 2
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -515,7 +515,7 @@ func parseHTMLError(r *http.Response) error {
 
 	r1 := getElementById(doc, "message")
 
-	return fmt.Errorf("Message: %v Headers: %v", r1.FirstChild.FirstChild.Data)
+	return fmt.Errorf("%v", r1.FirstChild.FirstChild.Data)
 }
 
 func GetAttribute(n *html.Node, key string) (string, bool) {

--- a/api/api.go
+++ b/api/api.go
@@ -126,7 +126,7 @@ type ClientOptions struct {
 	// Insecure is a flag that indicates whether or not to supress SSL errors.
 	Insecure bool
 
-	// VolumesPath is the location on the Iilon server where volumes are
+	// VolumesPath is the location on the Isilon server where volumes are
 	// stored.
 	VolumesPath string
 

--- a/api/api.go
+++ b/api/api.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -314,6 +315,7 @@ func (c *client) DoWithHeaders(
 		}
 		dec := json.NewDecoder(res.Body)
 		if err = dec.Decode(resp); err != nil && err != io.EOF {
+			fmt.Printf("Response Body Actual: %v", res.Body)
 			return err
 		}
 	default:

--- a/api/api.go
+++ b/api/api.go
@@ -79,7 +79,7 @@ type Client interface {
 		resp interface{}) error
 
 	// APIVersion returns the API version.
-	APIVersion() uint8
+	APIVersion() float32
 
 	// User returns the user name used to access the OneFS API.
 	User() string
@@ -455,7 +455,7 @@ func (c *client) DoAndGetResponseBody(
 	return res, isDebugLog, err
 }
 
-func (c *client) APIVersion() uint8 {
+func (c *client) APIVersion() float32 {
 	return c.apiv
 }
 

--- a/api/v1/api_v1.go
+++ b/api/v1/api_v1.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/thecodeteam/goisilon/api"
+	"github.com/hpanike/goisilon/api"
 )
 
 const (

--- a/api/v1/api_v1_exports.go
+++ b/api/v1/api_v1_exports.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/thecodeteam/goisilon/api"
+	"github.com/hpanike/goisilon/api"
 )
 
 // Export enables an NFS export on the cluster to access the volumes.  Return the path to the export

--- a/api/v1/api_v1_quotas.go
+++ b/api/v1/api_v1_quotas.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/thecodeteam/goisilon/api"
+	"github.com/hpanike/goisilon/api"
 )
 
 // GetIsiQuota queries the quota for a directory

--- a/api/v1/api_v1_snapshots.go
+++ b/api/v1/api_v1_snapshots.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/thecodeteam/goisilon/api"
+	"github.com/hpanike/goisilon/api"
 )
 
 // GetIsiSnapshots queries a list of all snapshots on the cluster

--- a/api/v1/api_v1_volumes.go
+++ b/api/v1/api_v1_volumes.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"path"
 
-	"github.com/thecodeteam/goisilon/api"
+	"github.com/hpanike/goisilon/api"
 )
 
 var (

--- a/api/v2/api_v2.go
+++ b/api/v2/api_v2.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/thecodeteam/goisilon/api"
+	"github.com/hpanike/goisilon/api"
 )
 
 const (

--- a/api/v2/api_v2_acls.go
+++ b/api/v2/api_v2_acls.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/thecodeteam/goisilon/api"
+	"github.com/hpanike/goisilon/api"
 	"context"
 )
 

--- a/api/v2/api_v2_exports.go
+++ b/api/v2/api_v2_exports.go
@@ -6,8 +6,8 @@ import (
 
 	"context"
 
-	"github.com/thecodeteam/goisilon/api"
-	"github.com/thecodeteam/goisilon/api/json"
+	"github.com/hpanike/goisilon/api"
+	"github.com/hpanike/goisilon/api/json"
 )
 
 // Export is an Isilon Export.

--- a/api/v2/api_v2_exports_test.go
+++ b/api/v2/api_v2_exports_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/thecodeteam/goisilon/api/json"
+	"github.com/hpanike/goisilon/api/json"
 )
 
 func TestExportEncodeJSON(t *testing.T) {

--- a/api/v2/api_v2_fs.go
+++ b/api/v2/api_v2_fs.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/thecodeteam/goisilon/api"
+	"github.com/hpanike/goisilon/api"
 	"context"
 )
 

--- a/client.go
+++ b/client.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/thecodeteam/goisilon/api"
+	"github.com/hpanike/goisilon/api"
 )
 
 // Client is an Isilon client.

--- a/client_test.go
+++ b/client_test.go
@@ -9,5 +9,5 @@ import (
 func TestNewClient(t *testing.T) {
 	assert.NotNil(t, client)
 	assert.NotZero(t, client.API.APIVersion())
-	t.Logf("api version=%d", client.API.APIVersion())
+	t.Logf("api version=%v", client.API.APIVersion())
 }

--- a/exports.go
+++ b/exports.go
@@ -3,7 +3,7 @@ package goisilon
 import (
 	"context"
 
-	api "github.com/thecodeteam/goisilon/api/v2"
+	api "github.com/hpanike/goisilon/api/v2"
 )
 
 type ExportList []*api.Export

--- a/quota.go
+++ b/quota.go
@@ -3,7 +3,7 @@ package goisilon
 import (
 	"context"
 
-	api "github.com/thecodeteam/goisilon/api/v1"
+	api "github.com/hpanike/goisilon/api/v1"
 )
 
 type Quota *api.IsiQuota

--- a/snapshots.go
+++ b/snapshots.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"path"
 
-	api "github.com/thecodeteam/goisilon/api/v1"
+	api "github.com/hpanike/goisilon/api/v1"
 )
 
 type SnapshotList []*api.IsiSnapshot

--- a/volume.go
+++ b/volume.go
@@ -9,8 +9,8 @@ import (
 
 	log "github.com/akutz/gournal"
 
-	apiv1 "github.com/thecodeteam/goisilon/api/v1"
-	apiv2 "github.com/thecodeteam/goisilon/api/v2"
+	apiv1 "github.com/hpanike/goisilon/api/v1"
+	apiv2 "github.com/hpanike/goisilon/api/v2"
 )
 
 type Volume *apiv1.IsiVolume

--- a/volume_test.go
+++ b/volume_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	apiv2 "github.com/thecodeteam/goisilon/api/v2"
+	apiv2 "github.com/hpanike/goisilon/api/v2"
 )
 
 func TestVolumeList(*testing.T) {


### PR DESCRIPTION
As of OneFS 8.1.X.X, the API return from /platform/lastest now returns a float (eg. 5.1 instead of 4).  This breaks the instantiation of a new client. By change all references and getter functions for apiv to float32, the client can be instantiated.  