### PR TITLE
fix json mapping for target_id for an IsiSnapshot

### DIFF
--- a/api/v1/api_v1_types.go
+++ b/api/v1/api_v1_types.go
@@ -88,7 +88,7 @@ type IsiSnapshot struct {
 	ShadowBytes   int64   `json:"shadow_bytes"`
 	Size          int64   `json:"size"`
 	State         string  `json:"state"`
-	TargetId      int64   `json:"target_it"`
+	TargetId      int64   `json:"target_id"`
 	TargetName    string  `json:"target_name"`
 }
 


### PR DESCRIPTION
fix json mapping for target_id for an IsiSnapshot. It should be `target_id` and not `target_it`.